### PR TITLE
fix: X 포스팅 파이프라인 개선 및 관리자 UX 수정

### DIFF
--- a/scripts/build-digest.mjs
+++ b/scripts/build-digest.mjs
@@ -53,8 +53,8 @@ function buildXThread(items, siteBaseUrl) {
       `git log --since="${todayKST}T00:00:00+09:00" --until="${todayKST}T23:59:59+09:00" --oneline -- data/items.json`,
       { encoding: 'utf-8', timeout: 5000 }
     ).trim();
-    // Current commit is not yet in log, so >=1 means there was a previous one today
-    if (log && log.split('\n').filter(Boolean).length >= 1) {
+    // In CI, current commit is already checked out, so log includes it; >=2 means a previous one exists
+    if (log && log.split('\n').filter(Boolean).length >= 2) {
       isAdditional = true;
     }
   } catch { /* git not available or not in repo — default to normal */ }

--- a/scripts/build-digest.mjs
+++ b/scripts/build-digest.mjs
@@ -17,7 +17,7 @@ function parseArgs(argv) {
  * Build X thread data: main tweet + reply per item.
  *
  * Main tweet:
- *   📌 NLP-Paper-News 업데이트 (6건)
+ *   📌 NLP-Paper-News · 2025.02.17 (월) 업데이트 (6건)
  *
  *   • Gaia2 (Meta)
  *   • LLaDA2.1 (Ant)
@@ -36,7 +36,14 @@ function buildXThread(items, siteBaseUrl) {
 
   // --- Main tweet ---
   const maxMain = 280;
-  const header = `📌 NLP-Paper-News 업데이트 (${items.length}건)\n\n`;
+  const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+  const now = new Date(new Date().toLocaleString('en-US', { timeZone: 'Asia/Seoul' }));
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  const day = dayNames[now.getDay()];
+  const dateStr = `${yyyy}.${mm}.${dd} (${day})`;
+  const header = `📌 NLP-Paper-News · ${dateStr} 업데이트 (${items.length}건)\n\n`;
   const footer = siteBaseUrl ? `\n\n👉 ${siteBaseUrl}` : '';
 
   // Fit as many items as possible into 280 chars, show "외 N건" for the rest

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -203,14 +203,14 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         </button>
       </div>
 
-      <!-- Submit Status (below buttons) -->
-      <div id="submit-status" class="hidden mt-4 p-4 rounded-xl text-sm"></div>
-
       <details class="mt-4">
         <summary class="text-xs text-gray-400 cursor-pointer hover:text-gray-600 transition-colors">JSON 출력 보기</summary>
         <pre id="json-output" class="mt-2 bg-gray-950 text-claude-300 p-4 rounded-lg overflow-x-auto text-xs font-mono"></pre>
       </details>
     </div>
+
+    <!-- Submit Status (outside preview-section so it survives clear) -->
+    <div id="submit-status" class="hidden mb-5 p-4 rounded-xl text-sm"></div>
 
     <!-- Confirm Modal -->
     <div id="confirm-modal" class="hidden fixed inset-0 z-50">

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -178,9 +178,6 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       <div id="parse-summary" class="hidden mt-3 p-3 rounded-lg bg-gray-50 dark:bg-anthro-darkMid border border-gray-200 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-300"></div>
     </div>
 
-    <!-- Submit Status (always visible) -->
-    <div id="submit-status" class="hidden mb-5 p-4 rounded-xl text-sm"></div>
-
     <!-- Preview -->
     <div id="preview-section" class="hidden mb-6">
       <div class="flex items-center justify-between mb-3">
@@ -205,6 +202,9 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
           JSON 복사
         </button>
       </div>
+
+      <!-- Submit Status (below buttons) -->
+      <div id="submit-status" class="hidden mt-4 p-4 rounded-xl text-sm"></div>
 
       <details class="mt-4">
         <summary class="text-xs text-gray-400 cursor-pointer hover:text-gray-600 transition-colors">JSON 출력 보기</summary>
@@ -552,7 +552,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         <div>입력 내부 중복(id): <span class="font-mono font-semibold">${localDuplicateCount}</span>건</div>
       `;
       if (alreadySubmitted.length > 0) {
-        summaryHtml += `<div class="mt-1 text-amber-600 dark:text-amber-400 font-semibold">이미 제출된 항목 ${alreadySubmitted.length}건 포함 (서버에서 중복 제거됨)</div>`;
+        summaryHtml += `<div class="mt-1 text-red-600 dark:text-red-400 font-semibold">⚠️ 이미 제출된 항목 ${alreadySubmitted.length}건 포함 — 미리보기에서 중복 항목을 제거해야 제출할 수 있습니다</div>`;
       }
       summaryEl.innerHTML = summaryHtml;
       summaryEl.classList.remove('hidden');
@@ -588,14 +588,18 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       const colors = TYPE_COLORS[item.type] || TYPE_COLORS.paper;
       const dateDisplay = `${item.year}.${String(item.month).padStart(2, '0')} ${item.week}주차`;
       const urlDomain = item.url ? (() => { try { return new URL(item.url).hostname.replace('www.', ''); } catch { return ''; } })() : '';
+      const isDuplicate = submittedIds.has(item.id);
+      const dupBorder = isDuplicate ? 'border-red-300 dark:border-red-800 opacity-60' : `${colors.border}/30`;
+      const dupBadge = isDuplicate ? '<span class="text-xs font-semibold text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-950/30 px-2 py-0.5 rounded-md">중복</span>' : '';
       return `
-        <div class="p-4 rounded-xl border ${colors.bg} ${colors.border}/30 relative group">
+        <div class="p-4 rounded-xl border ${colors.bg} ${dupBorder} relative group">
           <button class="remove-item absolute top-2 right-2 p-1 rounded-md text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-all" data-idx="${idx}">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
           </button>
           <div class="flex items-center gap-2 mb-2">
             <span class="text-xs font-bold ${colors.text}">${icon} ${item.type.toUpperCase()}</span>
             <span class="text-xs font-semibold text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-white/10 px-2 py-0.5 rounded-md">${escapeHtml(item.org)}</span>
+            ${dupBadge}
             <span class="text-xs text-gray-400 font-mono ml-auto">${dateDisplay}</span>
           </div>
           ${item.url
@@ -628,6 +632,31 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
     if (jsonOutput) {
       jsonOutput.textContent = JSON.stringify(parsedItems, null, 2);
+    }
+
+    // Disable submit if all items are already submitted duplicates
+    updateSubmitBtnState();
+  }
+
+  function updateSubmitBtnState() {
+    const submitBtn = document.getElementById('submit-btn') as HTMLButtonElement | null;
+    const label = document.getElementById('submit-btn-label');
+    if (!submitBtn || !label) return;
+
+    const newItems = parsedItems.filter(i => !submittedIds.has(i.id));
+    const duplicateCount = parsedItems.length - newItems.length;
+
+    if (parsedItems.length > 0 && newItems.length === 0) {
+      // All items are duplicates
+      submitBtn.disabled = true;
+      label.textContent = `제출 불가 (${duplicateCount}건 중복)`;
+    } else if (duplicateCount > 0) {
+      // Some duplicates — allow submit but warn
+      submitBtn.disabled = true;
+      label.textContent = `제출 불가 (${duplicateCount}건 중복 포함)`;
+    } else {
+      submitBtn.disabled = false;
+      label.textContent = '확인하고 추가';
     }
   }
 


### PR DESCRIPTION
## Summary
- PR #5 merge 이후 추가 수정사항 반영
- X 포스팅 파이프라인 버그 수정 및 이메일/Threads 코드 정리
- 관리자 페이지 UX 개선

## 변경사항
- **fix**: push 이벤트에서 항상 dry-run이었던 버그 수정, PR 이벤트에서 post_x/send_email 제외
- **refactor**: 이메일/Threads 관련 코드 전면 제거 (X 전용으로 정리)
- **fix**: 메인 트윗에 `YYYY.MM.DD (요일)` 날짜 표시, 동일 날짜 재포스팅 시 '추가 업데이트' 표시
- **fix**: 관리자 페이지 — 처리중 상태를 하단으로 이동, 중복 항목 포함 시 제출 버튼 비활성화

## Test plan
- [x] dry-run 포맷 검증
- [ ] merge 후 실제 항목 추가 시 X 자동 포스팅 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)