### PR TITLE
feat: X 포스팅 파이프라인 개선 및 Admin 버그 수정

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -100,6 +100,7 @@ jobs:
           name: notify-artifacts
           path: artifacts
       - name: Post to X
+        id: post
         env:
           X_API_KEY: ${{ secrets.X_API_KEY }}
           X_API_SECRET: ${{ secrets.X_API_SECRET }}
@@ -112,3 +113,13 @@ jobs:
             DRY_RUN_FLAG="--dry-run"
           fi
           node scripts/post-x.mjs --digest artifacts/digest.json $DRY_RUN_FLAG
+      - name: Post to X summary
+        if: always()
+        run: |
+          echo "## X Post Result" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.post.outcome }}" = "success" ]; then
+            echo "Thread posted successfully" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Thread posting failed** — replies were rolled back automatically." >> "$GITHUB_STEP_SUMMARY"
+            echo "Re-trigger this workflow to retry." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/scripts/build-digest.mjs
+++ b/scripts/build-digest.mjs
@@ -45,12 +45,12 @@ function buildXThread(items, siteBaseUrl) {
   const day = dayNames[now.getDay()];
   const dateStr = `${yyyy}.${mm}.${dd} (${day})`;
 
-  // Check if there was already a push to data/items.json today (KST)
+  // Check if there was already an item-adding push to data/items.json today (KST)
   let isAdditional = false;
   try {
     const todayKST = `${yyyy}-${mm}-${dd}`;
     const log = execSync(
-      `git log --since="${todayKST}T00:00:00+09:00" --until="${todayKST}T23:59:59+09:00" --oneline -- data/items.json`,
+      `git log --since="${todayKST}T00:00:00+09:00" --until="${todayKST}T23:59:59+09:00" --oneline --grep="^Add " -- data/items.json`,
       { encoding: 'utf-8', timeout: 5000 }
     ).trim();
     // In CI, current commit is already checked out, so log includes it; >=2 means a previous one exists
@@ -60,13 +60,13 @@ function buildXThread(items, siteBaseUrl) {
   } catch { /* git not available or not in repo — default to normal */ }
 
   const updateLabel = isAdditional ? '추가 업데이트' : '업데이트';
-  const header = `📌 NLP-Paper-News · ${dateStr} ${updateLabel} (${items.length}건)\n\n`;
+  const header = `📌 ${dateStr} ${updateLabel} (${items.length}건)\n\n`;
   const footer = siteBaseUrl ? `\n\n👉 ${siteBaseUrl}` : '';
 
   // Fit as many items as possible into 280 chars, show "외 N건" for the rest
   let mainText = '';
   for (let count = Math.min(items.length, 10); count >= 1; count--) {
-    const lines = items.slice(0, count).map((item) => `• ${item.title} (${item.org})`);
+    const lines = items.slice(0, count).map((item) => `• [${item.org}] ${item.title}`);
     const remaining = items.length - count;
     const moreLine = remaining > 0 ? `\n외 ${remaining}건` : '';
     const candidate = header + lines.join('\n') + moreLine + footer;
@@ -76,7 +76,7 @@ function buildXThread(items, siteBaseUrl) {
     }
   }
   if (!mainText) {
-    mainText = header + `• ${items[0].title} (${items[0].org})` +
+    mainText = header + `• [${items[0].org}] ${items[0].title}` +
       (items.length > 1 ? `\n외 ${items.length - 1}건` : '') + footer;
   }
 
@@ -86,7 +86,7 @@ function buildXThread(items, siteBaseUrl) {
   const replies = items.map((item, idx) => {
     const icon = typeIcon[item.type] || '📄';
     const num = `[${idx + 1}/${total}]`;
-    const titleLine = `${num} ${icon} ${item.title} (${item.org})`;
+    const titleLine = `${num} ${icon} [${item.org}] ${item.title}`;
     const headerPart = titleLine;
     const urlLine = item.url ? `\n🔗 ${item.url}` : '';
 

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -203,14 +203,14 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         </button>
       </div>
 
-      <!-- Submit Status (below the button) -->
-      <div id="submit-status" class="hidden mt-3 p-4 rounded-xl text-sm"></div>
-
       <details class="mt-4">
         <summary class="text-xs text-gray-400 cursor-pointer hover:text-gray-600 transition-colors">JSON 출력 보기</summary>
         <pre id="json-output" class="mt-2 bg-gray-950 text-claude-300 p-4 rounded-lg overflow-x-auto text-xs font-mono"></pre>
       </details>
     </div>
+
+    <!-- Submit Status (outside preview-section so it stays visible after submit clears items) -->
+    <div id="submit-status" class="hidden mt-3 p-4 rounded-xl text-sm"></div>
 
     <!-- Confirm Modal -->
     <div id="confirm-modal" class="hidden fixed inset-0 z-50">
@@ -1008,6 +1008,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       localStorage.setItem('github_token', input.value.trim());
       input.value = '';
       updateTokenStatus();
+      loadExistingIds(); // Reload with new token
       showToast('토큰이 저장되었습니다');
     }
   });
@@ -1029,12 +1030,13 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
   // ─── Init ──────────────────────────────
   updateTokenStatus();
-  loadExistingIds(); // Load existing item IDs from GitHub on page load
   const savedRepo = localStorage.getItem('github_repo');
   if (savedRepo) {
     (document.getElementById('github-repo') as HTMLInputElement).value = savedRepo;
   }
+  loadExistingIds(); // Load after repo value is restored
   document.getElementById('github-repo')?.addEventListener('change', (e) => {
     localStorage.setItem('github_repo', (e.target as HTMLInputElement).value);
+    loadExistingIds(); // Reload for new repo
   });
 </script>

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -203,14 +203,14 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         </button>
       </div>
 
+      <!-- Submit Status (below the button) -->
+      <div id="submit-status" class="hidden mt-3 p-4 rounded-xl text-sm"></div>
+
       <details class="mt-4">
         <summary class="text-xs text-gray-400 cursor-pointer hover:text-gray-600 transition-colors">JSON 출력 보기</summary>
         <pre id="json-output" class="mt-2 bg-gray-950 text-claude-300 p-4 rounded-lg overflow-x-auto text-xs font-mono"></pre>
       </details>
     </div>
-
-    <!-- Submit Status (outside preview-section so it survives clear) -->
-    <div id="submit-status" class="hidden mb-5 p-4 rounded-xl text-sm"></div>
 
     <!-- Confirm Modal -->
     <div id="confirm-modal" class="hidden fixed inset-0 z-50">
@@ -236,6 +236,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   let selectedType = 'paper';
   let pendingSubmitItems: any[] = [];
   let submittedIds = new Set<string>();
+  let existingIds = new Set<string>();  // IDs already committed to items.json
 
   // ─── Type colors ───────────────────────
   const TYPE_COLORS: Record<string, { border: string; bg: string; text: string }> = {
@@ -249,6 +250,40 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   const TYPE_MAP: Record<string, string> = {
     '📜': 'paper', '🧑🏻‍💻': 'dev', '🧑🏻💻': 'dev', '🗞️': 'news', '🗞': 'news',
   };
+
+  // ─── Load existing IDs from GitHub ─────
+  async function loadExistingIds() {
+    const token = localStorage.getItem('github_token');
+    if (!token) return;
+    const repo = (document.getElementById('github-repo') as HTMLInputElement)?.value || 'chanmuzi/NLP-Paper-News';
+    try {
+      const getRes = await fetch(`https://api.github.com/repos/${repo}/contents/data/items.json`, {
+        headers: { 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json' }
+      });
+      if (!getRes.ok) return;
+      const fileData = await getRes.json();
+
+      let base64Content: string;
+      if (fileData.content) {
+        base64Content = fileData.content.replace(/\n/g, '');
+      } else {
+        const blobRes = await fetch(`https://api.github.com/repos/${repo}/git/blobs/${fileData.sha}`, {
+          headers: { 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json' }
+        });
+        if (!blobRes.ok) return;
+        const blobData = await blobRes.json();
+        base64Content = blobData.content.replace(/\n/g, '');
+      }
+      const binaryStr = atob(base64Content);
+      const bytes = new Uint8Array(binaryStr.length);
+      for (let i = 0; i < binaryStr.length; i++) {
+        bytes[i] = binaryStr.charCodeAt(i);
+      }
+      const rawContent = new TextDecoder('utf-8').decode(bytes);
+      const data = JSON.parse(rawContent);
+      existingIds = new Set((data.items || []).map((i: any) => i.id));
+    } catch { /* silently fail — graceful degradation */ }
+  }
 
   // ─── Tab switching ─────────────────────
   const tabSimple = document.getElementById('tab-simple')!;
@@ -545,14 +580,19 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       renderPreview();
       const localDuplicateCount = getLocalDuplicateCount(result.items);
       const alreadySubmitted = result.items.filter(i => submittedIds.has(i.id));
+      const alreadyCommitted = result.items.filter(i => existingIds.has(i.id));
+      const realNewCount = result.items.filter(i => !submittedIds.has(i.id) && !existingIds.has(i.id)).length;
       let summaryHtml = `
         <div class="font-semibold text-gray-700 dark:text-gray-200 mb-1">파싱 테스트 완료</div>
-        <div>추가 후보: <span class="font-mono font-semibold">${result.items.length}</span>건</div>
+        <div>추가 후보: <span class="font-mono font-semibold">${realNewCount}</span>건${alreadyCommitted.length > 0 ? ` <span class="text-gray-400">(이미 커밋됨: ${alreadyCommitted.length}건)</span>` : ''}</div>
         <div>형식 오류: <span class="font-mono font-semibold">${result.errors.length}</span>건</div>
         <div>입력 내부 중복(id): <span class="font-mono font-semibold">${localDuplicateCount}</span>건</div>
       `;
+      if (alreadyCommitted.length > 0) {
+        summaryHtml += `<div class="mt-1 text-amber-600 dark:text-amber-400 font-semibold">이미 커밋된 항목 ${alreadyCommitted.length}건 포함 — 미리보기에서 제거하거나 그대로 두면 자동 건너뜁니다</div>`;
+      }
       if (alreadySubmitted.length > 0) {
-        summaryHtml += `<div class="mt-1 text-red-600 dark:text-red-400 font-semibold">⚠️ 이미 제출된 항목 ${alreadySubmitted.length}건 포함 — 미리보기에서 중복 항목을 제거해야 제출할 수 있습니다</div>`;
+        summaryHtml += `<div class="mt-1 text-red-600 dark:text-red-400 font-semibold">이미 제출된 항목 ${alreadySubmitted.length}건 포함 — 미리보기에서 중복 항목을 제거해야 제출할 수 있습니다</div>`;
       }
       summaryEl.innerHTML = summaryHtml;
       summaryEl.classList.remove('hidden');
@@ -588,9 +628,15 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       const colors = TYPE_COLORS[item.type] || TYPE_COLORS.paper;
       const dateDisplay = `${item.year}.${String(item.month).padStart(2, '0')} ${item.week}주차`;
       const urlDomain = item.url ? (() => { try { return new URL(item.url).hostname.replace('www.', ''); } catch { return ''; } })() : '';
-      const isDuplicate = submittedIds.has(item.id);
+      const isSessionDup = submittedIds.has(item.id);
+      const isExistingDup = existingIds.has(item.id);
+      const isDuplicate = isSessionDup || isExistingDup;
       const dupBorder = isDuplicate ? 'border-red-300 dark:border-red-800 opacity-60' : `${colors.border}/30`;
-      const dupBadge = isDuplicate ? '<span class="text-xs font-semibold text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-950/30 px-2 py-0.5 rounded-md">중복</span>' : '';
+      const dupBadge = isExistingDup
+        ? '<span class="text-xs font-semibold text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded-md">커밋 완료</span>'
+        : isSessionDup
+        ? '<span class="text-xs font-semibold text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-950/30 px-2 py-0.5 rounded-md">중복</span>'
+        : '';
       return `
         <div class="p-4 rounded-xl border ${colors.bg} ${dupBorder} relative group">
           <button class="remove-item absolute top-2 right-2 p-1 rounded-md text-gray-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-all" data-idx="${idx}">
@@ -643,15 +689,13 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     const label = document.getElementById('submit-btn-label');
     if (!submitBtn || !label) return;
 
-    const newItems = parsedItems.filter(i => !submittedIds.has(i.id));
+    const newItems = parsedItems.filter(i => !submittedIds.has(i.id) && !existingIds.has(i.id));
     const duplicateCount = parsedItems.length - newItems.length;
 
     if (parsedItems.length > 0 && newItems.length === 0) {
-      // All items are duplicates
       submitBtn.disabled = true;
       label.textContent = `제출 불가 (${duplicateCount}건 중복)`;
     } else if (duplicateCount > 0) {
-      // Some duplicates — allow submit but warn
       submitBtn.disabled = true;
       label.textContent = `제출 불가 (${duplicateCount}건 중복 포함)`;
     } else {
@@ -847,7 +891,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
       const skippedMsg = skippedCount > 0 ? ` (${skippedCount}개 중복 건너뜀)` : '';
       const shortSha = (newCommit.sha || '').slice(0, 7);
-      items.forEach(i => submittedIds.add(i.id));
+      items.forEach(i => { submittedIds.add(i.id); existingIds.add(i.id); });
       showStatus(`${newItems.length}개 항목 추가 완료${skippedMsg} · ${shortSha}`, 'success');
       parsedItems = [];
       renderPreview();
@@ -985,6 +1029,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
   // ─── Init ──────────────────────────────
   updateTokenStatus();
+  loadExistingIds(); // Load existing item IDs from GitHub on page load
   const savedRepo = localStorage.getItem('github_repo');
   if (savedRepo) {
     (document.getElementById('github-repo') as HTMLInputElement).value = savedRepo;


### PR DESCRIPTION
## Summary
- 메인 트윗/reply 포맷 변경: `[기관명] 제목`, NLP-Paper-News 텍스트 삭제
- Reply 실패 시 자동 롤백 (전체 스레드 삭제) + 에러 상세 로깅 + Job Summary
- 추가 업데이트 판정을 `Add` 커밋만 카운트하도록 수정
- Admin 파싱 미리보기에서 기존 커밋 항목 중복 감지 (`커밋 완료` 배지)
- submit-status 위치를 버튼 아래로 이동

## Test plan
- [ ] `build-digest.mjs` 로컬 실행 → `artifacts/digest.json` 포맷 확인
- [ ] `post-x.mjs --dry-run` → 출력 형식 확인
- [ ] Admin 페이지에서 기존 항목 파싱 시 "커밋 완료" 배지 표시 확인
- [ ] workflow_dispatch dry-run → Job Summary 확인
- [ ] 실제 포스팅 후 reply 스레드 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)