### PR TITLE
X 자동 포스팅 품질/안정화: AI 요약 스키마 재설계 + 280자 하드 가드

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -75,6 +75,7 @@ jobs:
           OPENAI_API_BASE: ${{ vars.OPENAI_API_BASE }}
           OPENAI_X_DEBUG: ${{ vars.OPENAI_X_DEBUG }}
           X_SAFE_LIMIT: ${{ vars.X_SAFE_LIMIT }}
+          X_GEN_MARGIN: ${{ vars.X_GEN_MARGIN }}
         run: node scripts/build-digest.mjs --input artifacts/new-items.json --out-dir artifacts --site-base-url "https://chanmuzi.github.io/NLP-Paper-News/"
 
       - name: Job summary
@@ -82,6 +83,29 @@ jobs:
         run: |
           echo "## Notify pipeline summary" >> "$GITHUB_STEP_SUMMARY"
           echo "- added_count: ${{ steps.delta.outputs.added_count }}" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f artifacts/digest.json ]; then
+            node -e "
+              const fs = require('fs');
+              const d = JSON.parse(fs.readFileSync('artifacts/digest.json','utf8'));
+              const m = d?.social?.x_thread_meta || {};
+              const replies = Array.isArray(m.reply_chars) ? m.reply_chars : [];
+              const maxReply = replies.length ? Math.max(...replies) : '-';
+              const lines = [];
+              lines.push('');
+              lines.push('### X generation meta');
+              lines.push('- generator: ' + (m.generator || '-'));
+              lines.push('- main_model: ' + (m.main_model || '-'));
+              lines.push('- reply_model: ' + (m.reply_model || '-'));
+              lines.push('- safe_limit: ' + (m.safe_limit ?? '-'));
+              lines.push('- hard_limit: ' + (m.hard_limit ?? '-'));
+              lines.push('- main_chars: ' + (m.main_chars ?? '-'));
+              lines.push('- max_reply_chars: ' + maxReply);
+              if (m.attempts) lines.push('- attempts: ' + JSON.stringify(m.attempts));
+              process.stdout.write(lines.join('\n'));
+            " >> "$GITHUB_STEP_SUMMARY"
+          fi
+
           if [ -f artifacts/social-draft.md ]; then
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "### Social draft preview" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -66,6 +66,12 @@ jobs:
 
       - name: Build digest
         if: steps.delta.outputs.has_new == 'true'
+        env:
+          ENABLE_AI_X_COPY: ${{ vars.ENABLE_AI_X_COPY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+          OPENAI_API_BASE: ${{ vars.OPENAI_API_BASE }}
+          X_SAFE_LIMIT: ${{ vars.X_SAFE_LIMIT }}
         run: node scripts/build-digest.mjs --input artifacts/new-items.json --out-dir artifacts --site-base-url "https://chanmuzi.github.io/NLP-Paper-News/"
 
       - name: Job summary
@@ -192,7 +198,7 @@ jobs:
                   lines.push('- failedAt: ' + (r.failedAt || '-') + '/' + (r.totalReplies || '-'));
                   lines.push('- httpStatus: ' + (r.httpStatus ?? '-'));
                   lines.push('- errorCode: ' + (r.errorCode || '-'));
-                  lines.push('- errorDetail: `' + (r.errorDetail || r.error || '-') + '`');
+                  lines.push('- errorDetail: ' + (r.errorDetail || r.error || '-'));
                 } else {
                   lines.push('✅ **Thread posted successfully**');
                 }
@@ -202,9 +208,7 @@ jobs:
                 r.posted.forEach((t,i) => lines.push('| ' + (i+1) + ' | ' + t.type + ' | [' + t.id + '](https://x.com/i/status/' + t.id + ') |'));
                 if (r.attempts) {
                   lines.push('');
-                  lines.push('```json');
-                  lines.push(JSON.stringify(r.attempts, null, 2));
-                  lines.push('```');
+                  lines.push('- attempts: ' + JSON.stringify(r.attempts));
                 }
               } else {
                 lines.push('❌ **Thread posting failed**');
@@ -214,7 +218,7 @@ jobs:
                 lines.push('- failedAt: ' + (r.failedAt || '-') + '/' + (r.totalReplies || '-'));
                 lines.push('- httpStatus: ' + (r.httpStatus ?? '-'));
                 lines.push('- errorCode: ' + (r.errorCode || '-'));
-                lines.push('- errorDetail: `' + (r.errorDetail || r.error || '-') + '`');
+                lines.push('- errorDetail: ' + (r.errorDetail || r.error || '-'));
                 lines.push('');
                 if (r.rolledBack > 0) {
                   lines.push('🔄 Rollback attempted: ' + r.rolledBack + ' tweet(s)');
@@ -222,9 +226,7 @@ jobs:
                 }
                 if (r.attempts) {
                   lines.push('');
-                  lines.push('```json');
-                  lines.push(JSON.stringify(r.attempts, null, 2));
-                  lines.push('```');
+                  lines.push('- attempts: ' + JSON.stringify(r.attempts));
                 }
                 lines.push('');
                 lines.push('Re-trigger this workflow to retry.');

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -70,7 +70,10 @@ jobs:
           ENABLE_AI_X_COPY: ${{ vars.ENABLE_AI_X_COPY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+          OPENAI_MODEL_MAIN: ${{ vars.OPENAI_MODEL_MAIN }}
+          OPENAI_MODEL_REPLY: ${{ vars.OPENAI_MODEL_REPLY }}
           OPENAI_API_BASE: ${{ vars.OPENAI_API_BASE }}
+          OPENAI_X_DEBUG: ${{ vars.OPENAI_X_DEBUG }}
           X_SAFE_LIMIT: ${{ vars.X_SAFE_LIMIT }}
         run: node scripts/build-digest.mjs --input artifacts/new-items.json --out-dir artifacts --site-base-url "https://chanmuzi.github.io/NLP-Paper-News/"
 

--- a/docs/notification-runbook.md
+++ b/docs/notification-runbook.md
@@ -27,15 +27,18 @@
 ## AI 카피 생성(선택)
 - `ENABLE_AI_X_COPY`: `true`/`false` (기본 `false`)
   - `true`면 OpenAI 모델로 main/reply 초안을 생성하고, 길이 검증 실패 시 재시도 후 규칙 기반으로 자동 fallback
-- `OPENAI_MODEL`: 기본 권장 `gpt-4.1-mini`
+- `OPENAI_MODEL`: 공통 모델 (미설정 시 기본 후보 자동 사용)
+- `OPENAI_MODEL_MAIN`: 메인 포스트 전용 모델 (선택)
+- `OPENAI_MODEL_REPLY`: reply 전용 모델 (선택)
 - `OPENAI_API_BASE`: 기본 `https://api.openai.com/v1` (대부분 미설정)
+- `OPENAI_X_DEBUG`: `true`면 프롬프트/입출력 디버그를 `artifacts/openai-x-copy-debug.json`으로 저장
 
 필수 시크릿:
 - `OPENAI_API_KEY`
 
 > 추천 세팅
 > - `ENABLE_AI_X_COPY=true`
-> - `OPENAI_MODEL=gpt-4.1-mini`
+> - `OPENAI_MODEL=gpt-4.1-mini` (또는 원하는 모델)
 > - `X_SAFE_LIMIT=275`
 
 ## 필수 시크릿 (GitHub Secrets)

--- a/docs/notification-runbook.md
+++ b/docs/notification-runbook.md
@@ -22,6 +22,21 @@
 - `X_DEGRADE_REPLY_403_429`: `true`/`false` (기본 `true`)
   - `true`: reply가 403/429로 막히면 main tweet은 유지하고 **degraded(main_only)** 처리
   - `false`: 기존처럼 reply 실패 시 전체 롤백
+- `X_SAFE_LIMIT`: X 글자수 안전 상한(기본 `275`, 최대 `280`)
+
+## AI 카피 생성(선택)
+- `ENABLE_AI_X_COPY`: `true`/`false` (기본 `false`)
+  - `true`면 OpenAI 모델로 main/reply 초안을 생성하고, 길이 검증 실패 시 재시도 후 규칙 기반으로 자동 fallback
+- `OPENAI_MODEL`: 기본 권장 `gpt-4.1-mini`
+- `OPENAI_API_BASE`: 기본 `https://api.openai.com/v1` (대부분 미설정)
+
+필수 시크릿:
+- `OPENAI_API_KEY`
+
+> 추천 세팅
+> - `ENABLE_AI_X_COPY=true`
+> - `OPENAI_MODEL=gpt-4.1-mini`
+> - `X_SAFE_LIMIT=275`
 
 ## 필수 시크릿 (GitHub Secrets)
 


### PR DESCRIPTION
## 배경
- 기존 AI 카피 생성 결과가 원문 재배치에 가까워 요약 품질과 일관성이 부족했습니다.
- reply 실패(특히 403/429) 대응 정책과 별개로, 생성 품질/길이 안정성 강화를 요청받았습니다.

## 주요 변경
1. scripts/build-digest.mjs 전면 개편
   - 메인 1회 + 리플 배치 1회로 목적 분리 호출
   - 프롬프트에 메인/리플 스타일 예시를 직접 포함
   - 출력은 엄격한 JSON 스키마 필드만 허용
   - 최종 텍스트는 템플릿 렌더링으로 일관성 확보
   - 길이 초과 항목만 재작성 루프 적용

2. 길이 검증/하드 가드 강화
   - X 가중치 길이 계산(링크 23, 한글/이모지 가중) 일관 적용
   - scripts/post-x.mjs 게시 직전 validation 실패 시 즉시 중단
   - postTweet 내부에도 local_length_guard 2중 방어 추가

3. 가시성 개선
   - .github/workflows/notify.yml Job Summary에 x_thread_meta(모델/길이/시도 정보) 노출
   - docs/notification-runbook.md에 로컬 검증 커맨드(build-digest/debug/dry-run) 명시

## 로컬 검증
- node --check scripts/build-digest.mjs
- node --check scripts/post-x.mjs
- ENABLE_AI_X_COPY=true OPENAI_X_DEBUG=true node scripts/build-digest.mjs --input artifacts/new-items.json --out-dir artifacts --site-base-url "https://chanmuzi.github.io/NLP-Paper-News/"
- node scripts/post-x.mjs --digest artifacts/digest.json --dry-run

참고: 현재 로컬 셸에서 OPENAI_API_KEY가 감지되지 않아 AI 실호출은 fallback(rule) 경로로 확인되었습니다.

## 기대 효과
- 메인/리플 텍스트 형식 통일
- 불필요한 장문/과장 감소 및 핵심 요약 강화
- 280자 초과 게시 시도 방지(하드 가드)
