### PR TITLE
항목 추가 후 X 게시 승인 플로우 개선 (draft 검토/수정 + mock 테스트 지원)

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -112,168 +112,38 @@ jobs:
             head -n 40 artifacts/social-draft.md >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Emit X draft payload for approval UI
+        if: steps.delta.outputs.has_new == 'true' && hashFiles('artifacts/digest.json') != ''
+        run: |
+          node -e "
+            const fs = require('fs');
+            const d = JSON.parse(fs.readFileSync('artifacts/digest.json','utf8'));
+            const thread = d?.social?.x_thread || {};
+            const meta = d?.social?.x_thread_meta || {};
+            const payload = {
+              generated_at: new Date().toISOString(),
+              commit_sha: process.env.GITHUB_SHA || '',
+              thread: {
+                main: String(thread.main || ''),
+                replies: Array.isArray(thread.replies) ? thread.replies.map((x) => String(x || '')) : []
+              },
+              meta: {
+                generator: meta.generator || 'rule',
+                main_model: meta.main_model || '-',
+                reply_model: meta.reply_model || '-',
+                safe_limit: meta.safe_limit ?? null,
+                hard_limit: meta.hard_limit ?? 280,
+                main_chars: meta.main_chars ?? null,
+                reply_chars: Array.isArray(meta.reply_chars) ? meta.reply_chars : []
+              }
+            };
+            const b64 = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64');
+            console.log('X_DRAFT_PAYLOAD_BASE64=' + b64);
+          "
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: notify-artifacts
           path: artifacts/
-
-  post_x:
-    runs-on: ubuntu-latest
-    needs: prepare
-    if: needs.prepare.outputs.has_new == 'true' && vars.ENABLE_X_POST == 'true' && github.event_name != 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-      - uses: actions/download-artifact@v4
-        with:
-          name: notify-artifacts
-          path: artifacts
-      - name: Cooldown guard
-        env:
-          GH_TOKEN: ${{ github.token }}
-          X_POST_COOLDOWN_SECONDS: ${{ vars.X_POST_COOLDOWN_SECONDS }}
-          CURRENT_RUN_ID: ${{ github.run_id }}
-        run: |
-          COOLDOWN="${X_POST_COOLDOWN_SECONDS:-180}"
-          if ! [[ "$COOLDOWN" =~ ^[0-9]+$ ]]; then
-            COOLDOWN=180
-          fi
-
-          if ! RUNS_JSON=$(gh api "repos/${{ github.repository }}/actions/workflows/notify.yml/runs?per_page=20"); then
-            echo "Cooldown guard skipped: unable to fetch previous runs."
-            exit 0
-          fi
-
-          WAIT_SECS=$(RUNS_JSON="$RUNS_JSON" COOLDOWN="$COOLDOWN" CURRENT_RUN_ID="$CURRENT_RUN_ID" node -e "
-            const data = JSON.parse(process.env.RUNS_JSON || '{}');
-            const runs = data.workflow_runs || [];
-            const current = Number(process.env.CURRENT_RUN_ID || 0);
-            const cooldown = Number(process.env.COOLDOWN || 180);
-            const now = Date.now();
-
-            const candidates = runs.filter((r) =>
-              r.id !== current &&
-              r.status === 'completed' &&
-              r.head_branch === 'main' &&
-              r.event !== 'pull_request'
-            );
-
-            if (!candidates.length) {
-              process.stdout.write('0');
-              process.exit(0);
-            }
-
-            const latest = candidates.reduce((a, b) =>
-              new Date(a.created_at || 0) > new Date(b.created_at || 0) ? a : b
-            );
-            const createdMs = Date.parse(latest.created_at || '');
-            const elapsed = Number.isFinite(createdMs) ? Math.max(0, Math.floor((now - createdMs) / 1000)) : cooldown;
-            const wait = Math.max(0, cooldown - elapsed);
-            process.stdout.write(String(wait));
-          " || echo 0)
-          WAIT_SECS="${WAIT_SECS:-0}"
-
-          if [ "$WAIT_SECS" -gt 0 ]; then
-            echo "Recent workflow detected. Cooling down for ${WAIT_SECS}s to reduce X anti-spam blocks..."
-            sleep "$WAIT_SECS"
-          else
-            echo "Cooldown guard passed (no additional wait)."
-          fi
-      - name: Post to X
-        id: post
-        env:
-          X_API_KEY: ${{ secrets.X_API_KEY }}
-          X_API_SECRET: ${{ secrets.X_API_SECRET }}
-          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
-          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
-          X_API_BASE: ${{ vars.X_API_BASE }}
-          X_DEGRADE_REPLY_403_429: ${{ vars.X_DEGRADE_REPLY_403_429 }}
-        run: |
-          CMD=(node scripts/post-x.mjs --digest artifacts/digest.json --result artifacts/post-result.json)
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
-            CMD+=(--dry-run)
-          fi
-
-          # 테스트 모드(workflow_dispatch)에서만 suffix 적용
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            CMD+=(--test-suffix " · test:${GITHUB_SHA::7}")
-          fi
-
-          "${CMD[@]}"
-      - name: Post to X summary
-        if: always()
-        run: |
-          echo "## X Post Result" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f artifacts/post-result.json ]; then
-            node -e "
-              const r = JSON.parse(require('fs').readFileSync('artifacts/post-result.json','utf8'));
-              const lines = [];
-              if (r.success) {
-                if (r.degradedMode === 'main_only') {
-                  lines.push('⚠️ **Posted in degraded mode (main only)**');
-                  lines.push('');
-                  lines.push('- reason: reply blocked by X anti-spam/rate policy');
-                  lines.push('- manual follow-up: add remaining replies manually if needed');
-                  lines.push('');
-                  lines.push('**Failure context**');
-                  lines.push('- failurePhase: ' + (r.failurePhase || '-'));
-                  lines.push('- failedAt: ' + (r.failedAt || '-') + '/' + (r.totalReplies || '-'));
-                  lines.push('- httpStatus: ' + (r.httpStatus ?? '-'));
-                  lines.push('- errorCode: ' + (r.errorCode || '-'));
-                  lines.push('- errorDetail: ' + (r.errorDetail || r.error || '-'));
-                } else {
-                  lines.push('✅ **Thread posted successfully**');
-                }
-                lines.push('');
-                lines.push('| # | Type | Tweet ID |');
-                lines.push('|---|------|----------|');
-                r.posted.forEach((t,i) => lines.push('| ' + (i+1) + ' | ' + t.type + ' | [' + t.id + '](https://x.com/i/status/' + t.id + ') |'));
-                if (r.attempts) {
-                  lines.push('');
-                  lines.push('- attempts: ' + JSON.stringify(r.attempts));
-                }
-              } else {
-                lines.push('❌ **Thread posting failed**');
-                lines.push('');
-                lines.push('**Failure context**');
-                lines.push('- failurePhase: ' + (r.failurePhase || '-'));
-                lines.push('- failedAt: ' + (r.failedAt || '-') + '/' + (r.totalReplies || '-'));
-                lines.push('- httpStatus: ' + (r.httpStatus ?? '-'));
-                lines.push('- errorCode: ' + (r.errorCode || '-'));
-                lines.push('- errorDetail: ' + (r.errorDetail || r.error || '-'));
-                lines.push('');
-                if (r.rolledBack > 0) {
-                  lines.push('🔄 Rollback attempted: ' + r.rolledBack + ' tweet(s)');
-                  lines.push('🧹 Rollback deleted: ' + (r.rollbackDeleted ?? 0) + ' tweet(s)');
-                }
-                if (r.attempts) {
-                  lines.push('');
-                  lines.push('- attempts: ' + JSON.stringify(r.attempts));
-                }
-                lines.push('');
-                lines.push('Re-trigger this workflow to retry.');
-              }
-              process.stdout.write(lines.join('\n'));
-            " >> "$GITHUB_STEP_SUMMARY"
-          elif [ "${{ steps.post.outcome }}" = "success" ]; then
-            echo "✅ Thread posted successfully" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "❌ **Thread posting failed**" >> "$GITHUB_STEP_SUMMARY"
-            echo "Re-trigger this workflow to retry." >> "$GITHUB_STEP_SUMMARY"
-          fi
-      - name: Upload post diagnostics
-        if: always() && hashFiles('artifacts/post-result.json') != ''
-        uses: actions/upload-artifact@v4
-        with:
-          name: post-x-result
-          path: artifacts/post-result.json
-      - name: Trigger deploy on success
-        if: steps.post.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run deploy.yml --ref main

--- a/.github/workflows/post-approved.yml
+++ b/.github/workflows/post-approved.yml
@@ -105,6 +105,16 @@ jobs:
             " >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Emit post result payload
+        if: always() && hashFiles('artifacts/post-result.json') != ''
+        run: |
+          node -e "
+            const fs = require('fs');
+            const raw = fs.readFileSync('artifacts/post-result.json', 'utf8');
+            const b64 = Buffer.from(raw, 'utf8').toString('base64');
+            console.log('POST_RESULT_BASE64=' + b64);
+          "
+
       - name: Upload post diagnostics
         if: always() && hashFiles('artifacts/post-result.json') != ''
         uses: actions/upload-artifact@v4

--- a/.github/workflows/post-approved.yml
+++ b/.github/workflows/post-approved.yml
@@ -1,0 +1,119 @@
+name: Post Approved X Thread
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "items.json 커밋 SHA (추적용)"
+        required: true
+        type: string
+      approval_mode:
+        description: "manual_approved | one_time_auto"
+        required: true
+        default: manual_approved
+        type: string
+      thread_json_b64:
+        description: "최종 승인 thread JSON(base64)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  post_x:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Decode approved thread and build digest
+        run: |
+          mkdir -p artifacts
+          THREAD_B64='${{ inputs.thread_json_b64 }}' node -e "
+            const fs = require('fs');
+            const raw = Buffer.from(String(process.env.THREAD_B64 || ''), 'base64').toString('utf8');
+            const parsed = JSON.parse(raw || '{}');
+            const replies = Array.isArray(parsed.replies) ? parsed.replies.map((x) => String(x || '')) : [];
+            const digest = {
+              generated_at: new Date().toISOString(),
+              added_count: replies.length,
+              items: [],
+              social: {
+                x_thread: {
+                  main: String(parsed.main || ''),
+                  replies,
+                },
+                x_thread_meta: {
+                  generator: 'approved_ui',
+                  approval_mode: '${{ inputs.approval_mode }}',
+                  approved_commit_sha: '${{ inputs.commit_sha }}',
+                  hard_limit: 280,
+                }
+              }
+            };
+            fs.writeFileSync('artifacts/digest.json', JSON.stringify(digest, null, 2), 'utf8');
+          "
+
+      - name: Post to X
+        id: post
+        env:
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          X_API_BASE: ${{ vars.X_API_BASE }}
+          X_DEGRADE_REPLY_403_429: ${{ vars.X_DEGRADE_REPLY_403_429 }}
+        run: node scripts/post-x.mjs --digest artifacts/digest.json --result artifacts/post-result.json
+
+      - name: Post to X summary
+        if: always()
+        run: |
+          echo "## X Post Result" >> "$GITHUB_STEP_SUMMARY"
+          echo "- commit_sha: ${{ inputs.commit_sha }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- approval_mode: ${{ inputs.approval_mode }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f artifacts/post-result.json ]; then
+            node -e "
+              const r = JSON.parse(require('fs').readFileSync('artifacts/post-result.json','utf8'));
+              const lines = [];
+              if (r.success) {
+                if (r.degradedMode === 'main_only') {
+                  lines.push('⚠️ **Posted in degraded mode (main only)**');
+                  lines.push('');
+                  lines.push('- reason: reply blocked by X anti-spam/rate policy');
+                  lines.push('- manual follow-up: add remaining replies manually if needed');
+                } else {
+                  lines.push('✅ **Thread posted successfully**');
+                }
+                lines.push('');
+                lines.push('| # | Type | Tweet ID |');
+                lines.push('|---|------|----------|');
+                (r.posted || []).forEach((t,i) => lines.push('| ' + (i+1) + ' | ' + t.type + ' | [' + t.id + '](https://x.com/i/status/' + t.id + ') |'));
+              } else {
+                lines.push('❌ **Thread posting failed**');
+                lines.push('');
+                lines.push('- failurePhase: ' + (r.failurePhase || '-'));
+                lines.push('- failedAt: ' + (r.failedAt || '-') + '/' + (r.totalReplies || '-'));
+                lines.push('- httpStatus: ' + (r.httpStatus ?? '-'));
+                lines.push('- errorCode: ' + (r.errorCode || '-'));
+                lines.push('- errorDetail: ' + (r.errorDetail || r.error || '-'));
+              }
+              process.stdout.write(lines.join('\n'));
+            " >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload post diagnostics
+        if: always() && hashFiles('artifacts/post-result.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-x-result
+          path: artifacts/post-result.json
+
+      - name: Trigger deploy on success
+        if: steps.post.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run deploy.yml --ref main

--- a/.github/workflows/rewrite-x-draft.yml
+++ b/.github/workflows/rewrite-x-draft.yml
@@ -1,0 +1,66 @@
+name: Rewrite X Draft
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "items.json commit SHA"
+        required: true
+        type: string
+      instruction:
+        description: "rewrite instruction"
+        required: true
+        type: string
+      current_thread_json_b64:
+        description: "current thread JSON(base64)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  rewrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Decode current thread
+        run: |
+          mkdir -p artifacts
+          THREAD_B64='${{ inputs.current_thread_json_b64 }}' node -e "
+            const fs = require('fs');
+            const raw = Buffer.from(String(process.env.THREAD_B64 || ''), 'base64').toString('utf8');
+            fs.writeFileSync('artifacts/current-thread.json', raw, 'utf8');
+          "
+
+      - name: Rewrite with AI
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+          OPENAI_MODEL_REPLY: ${{ vars.OPENAI_MODEL_REPLY }}
+          OPENAI_API_BASE: ${{ vars.OPENAI_API_BASE }}
+        run: |
+          node scripts/rewrite-x-thread.mjs \
+            --thread artifacts/current-thread.json \
+            --instruction "${{ inputs.instruction }}" \
+            --out artifacts/rewrite-result.json
+
+      - name: Emit rewrite payload
+        if: always() && hashFiles('artifacts/rewrite-result.json') != ''
+        run: |
+          node -e "
+            const fs = require('fs');
+            const raw = fs.readFileSync('artifacts/rewrite-result.json', 'utf8');
+            console.log('REWRITE_RESULT_BASE64=' + Buffer.from(raw, 'utf8').toString('base64'));
+          "
+
+      - name: Upload rewrite diagnostics
+        if: always() && hashFiles('artifacts/rewrite-result.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: rewrite-x-result
+          path: artifacts/rewrite-result.json

--- a/scripts/rewrite-x-thread.mjs
+++ b/scripts/rewrite-x-thread.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+import fs from 'fs';
+
+const X_HARD_LIMIT = 280;
+const URL_REGEX = /https?:\/\/[^\s)]+/gi;
+
+function parseArgs(argv) {
+  const args = { thread: '', instruction: '', out: 'artifacts/rewrite-result.json' };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--thread') args.thread = argv[++i];
+    else if (argv[i] === '--instruction') args.instruction = argv[++i];
+    else if (argv[i] === '--out') args.out = argv[++i];
+  }
+  return args;
+}
+
+function countXChars(text) {
+  const normalized = String(text || '').replace(URL_REGEX, 'x'.repeat(23));
+  const codepoint = Array.from(normalized).length;
+  try {
+    const seg = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+    return Math.max(codepoint, Array.from(seg.segment(normalized)).length);
+  } catch {
+    return codepoint;
+  }
+}
+
+function parseJsonSafely(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    const first = text.indexOf('{');
+    const last = text.lastIndexOf('}');
+    if (first >= 0 && last > first) {
+      try { return JSON.parse(text.slice(first, last + 1)); } catch {}
+    }
+    return null;
+  }
+}
+
+function getModelCandidates() {
+  const primary = String(process.env.OPENAI_MODEL_REPLY || '').trim();
+  const common = String(process.env.OPENAI_MODEL || '').trim();
+  const defaults = ['gpt-5.2', 'gpt-4.1-mini', 'gpt-4o-mini'];
+  return [...new Set([primary, common, ...defaults].filter(Boolean))];
+}
+
+async function callOpenAI({ apiKey, model, payload }) {
+  const endpointBase = String(process.env.OPENAI_API_BASE || 'https://api.openai.com/v1').replace(/\/$/, '');
+  const res = await fetch(`${endpointBase}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.2,
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'rewrite_x_thread_v1',
+          strict: true,
+          schema: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              main: { type: 'string' },
+              replies: { type: 'array', items: { type: 'string' } },
+            },
+            required: ['main', 'replies'],
+          },
+        },
+      },
+      messages: [
+        {
+          role: 'system',
+          content: [
+            'You are an editor for Korean X threads.',
+            'Apply the user instruction to main/replies.',
+            `Every post must stay within ${X_HARD_LIMIT} weighted characters.`,
+            'Do not invent facts. Keep links if present.',
+            'Return JSON only.',
+          ].join('\n')
+        },
+        { role: 'user', content: JSON.stringify(payload) },
+      ]
+    }),
+  });
+
+  const raw = await res.text();
+  if (!res.ok) throw new Error(`OpenAI API error (${res.status}): ${raw.slice(0, 400)}`);
+  const body = parseJsonSafely(raw);
+  const content = body?.choices?.[0]?.message?.content || raw;
+  const parsed = parseJsonSafely(content);
+  if (!parsed) throw new Error('OpenAI JSON parse failed');
+  return parsed;
+}
+
+function validateThread(thread) {
+  const failures = [];
+  const mainUsed = countXChars(thread.main || '');
+  if (mainUsed > X_HARD_LIMIT) failures.push({ phase: 'main', used: mainUsed });
+  (thread.replies || []).forEach((r, i) => {
+    const used = countXChars(r || '');
+    if (used > X_HARD_LIMIT) failures.push({ phase: `reply_${i + 1}`, used });
+  });
+  return failures;
+}
+
+async function main() {
+  const { thread: threadPath, instruction, out } = parseArgs(process.argv);
+  if (!threadPath || !instruction) {
+    console.error('Usage: node scripts/rewrite-x-thread.mjs --thread <json> --instruction <text> [--out artifacts/rewrite-result.json]');
+    process.exit(1);
+  }
+
+  const apiKey = String(process.env.OPENAI_API_KEY || '').trim();
+  if (!apiKey) {
+    console.error('OPENAI_API_KEY not set');
+    process.exit(1);
+  }
+
+  const original = JSON.parse(fs.readFileSync(threadPath, 'utf8'));
+  const models = getModelCandidates();
+
+  let selectedModel = '';
+  let rewritten = null;
+  let errorMessage = '';
+
+  for (const model of models) {
+    try {
+      const candidate = await callOpenAI({
+        apiKey,
+        model,
+        payload: {
+          instruction,
+          original_thread: {
+            main: String(original.main || ''),
+            replies: Array.isArray(original.replies) ? original.replies.map((x) => String(x || '')) : [],
+          },
+        },
+      });
+
+      const normalized = {
+        main: String(candidate.main || ''),
+        replies: Array.isArray(candidate.replies) ? candidate.replies.map((x) => String(x || '')) : [],
+      };
+
+      const failures = validateThread(normalized);
+      if (failures.length === 0) {
+        selectedModel = model;
+        rewritten = normalized;
+        break;
+      }
+      errorMessage = `length_over_limit:${JSON.stringify(failures)}`;
+    } catch (err) {
+      errorMessage = err.message || String(err);
+    }
+  }
+
+  const result = rewritten
+    ? {
+        success: true,
+        thread: rewritten,
+        meta: { model: selectedModel, instruction, hard_limit: X_HARD_LIMIT },
+      }
+    : {
+        success: false,
+        error: errorMessage || 'rewrite_failed',
+        thread: {
+          main: String(original.main || ''),
+          replies: Array.isArray(original.replies) ? original.replies.map((x) => String(x || '')) : [],
+        },
+        meta: { model: null, instruction, hard_limit: X_HARD_LIMIT },
+      };
+
+  fs.mkdirSync(out.split('/').slice(0, -1).join('/') || '.', { recursive: true });
+  fs.writeFileSync(out, JSON.stringify(result, null, 2), 'utf8');
+  console.log(`rewrite_saved=${out}`);
+}
+
+main().catch((err) => {
+  console.error(`rewrite failed: ${err.message}`);
+  process.exit(1);
+});

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -1230,7 +1230,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       setSubmitLoading(false);
 
       // Start workflow polling
-      showStatus(`✅ 커밋 완료${skippedMsg} · ${shortSha}\n⏳ X 초안 생성 워크플로 대기 중...`, 'info');
+      showStatus(`✅ 커밋 완료${skippedMsg} · ${shortSha}\n⏳ X draft 생성 워크플로 대기 중...`, 'info');
       currentCommittedSha = newCommit.sha;
       currentRepoForSubmit = repo;
       startWorkflowTracking(repo, token, newCommit.sha, newItems.length, undefined, requireManualApprovalForCurrentSubmit);
@@ -1358,7 +1358,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   async function dispatchApprovedPost(repo: string, token: string, commitSha: string, approvalMode: 'manual_approved' | 'one_time_auto') {
     const thread = collectEditedThread();
     if (!thread) {
-      showStatus('X 초안을 불러오지 못했습니다.', 'error');
+      showStatus('X draft를 불러오지 못했습니다.', 'error');
       return;
     }
 
@@ -1551,7 +1551,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
                 showStatus(`✅ 커밋 완료 · ${shortSha}\n📝 X draft가 준비되었습니다. draft를 확인한 뒤 승인해 주세요.`, 'success', { autoScroll: true });
               }
             } else {
-              showStatus(`✅ 커밋 완료 · ${shortSha}\n⚠️ X 초안을 찾지 못했습니다. Actions에서 notify-artifacts를 확인하세요.`, 'warn');
+              showStatus(`✅ 커밋 완료 · ${shortSha}\n⚠️ X draft를 찾지 못했습니다. Actions에서 notify-artifacts를 확인하세요.`, 'warn');
             }
           } else {
             showStatus(`✅ 커밋 완료 · ${shortSha}\n❌ 워크플로 ${runConclusion || '실패'}`, 'error');
@@ -1804,7 +1804,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       return;
     }
     if (!xDraftData || !currentCommittedSha || !currentRepoForSubmit) {
-      showStatus('승인할 X 초안이 없습니다. 먼저 항목을 커밋해 주세요.', 'warn');
+      showStatus('승인할 X draft가 없습니다. 먼저 항목을 커밋해 주세요.', 'warn');
       return;
     }
     if (!(xMainApproved && xRepliesApproved)) {

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -212,6 +212,29 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     <!-- Submit Status (outside preview-section so it stays visible after submit clears items) -->
     <div id="submit-status" class="hidden mt-3 p-4 rounded-xl text-sm"></div>
 
+    <!-- X Draft Review -->
+    <div id="x-review-section" class="hidden mt-5 p-4 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-anthro-darkSurface">
+      <div class="flex items-center justify-between mb-3">
+        <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-200">X 게시 전 문안 검토</h3>
+        <span id="x-review-meta" class="text-xs text-gray-400"></span>
+      </div>
+
+      <div class="space-y-3">
+        <div>
+          <label class="block text-xs text-gray-500 mb-1">Main post</label>
+          <textarea id="x-main-input" rows="4" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"></textarea>
+          <div id="x-main-count" class="mt-1 text-xs text-gray-400 font-mono">0/280</div>
+        </div>
+        <div id="x-replies-editor" class="space-y-2"></div>
+      </div>
+
+      <div class="mt-4 flex flex-wrap gap-2">
+        <button id="x-approve-post-btn" class="px-4 py-2 rounded-lg bg-claude-500 text-white text-sm font-semibold hover:bg-claude-600 transition-all">승인하고 X 게시</button>
+        <button id="x-copy-thread-btn" class="px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-300 hover:border-claude-400 transition-all">스레드 복사</button>
+      </div>
+      <div id="x-review-note" class="mt-2 text-xs text-gray-400"></div>
+    </div>
+
     <!-- Confirm Modal -->
     <div id="confirm-modal" class="hidden fixed inset-0 z-50">
       <div id="confirm-backdrop" class="absolute inset-0 bg-black/40 animate-fade-in"></div>
@@ -220,6 +243,10 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
           <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3">항목 추가 확인</h3>
           <p id="confirm-message" class="text-sm text-gray-600 dark:text-gray-300 mb-2"></p>
           <div id="confirm-item-list" class="mb-4 max-h-40 overflow-y-auto text-xs text-gray-500 dark:text-gray-400 space-y-1"></div>
+          <label class="mb-4 flex items-start gap-2 text-xs text-gray-600 dark:text-gray-300">
+            <input type="checkbox" id="confirm-manual-approval" class="mt-0.5 accent-claude-500" checked />
+            <span>X 게시 전 문안 확인/수정 후 승인하기 (기본)</span>
+          </label>
           <div class="flex gap-2">
             <button id="confirm-cancel" class="flex-1 px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all">취소</button>
             <button id="confirm-submit" class="flex-1 px-4 py-2.5 rounded-lg bg-claude-500 text-white text-sm font-semibold hover:bg-claude-600 transition-all">추가 실행</button>
@@ -238,8 +265,38 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   let submittedIds = new Set<string>();
   let existingIds = new Set<string>();  // IDs already committed to items.json
   let hasActiveWorkflowTracking = false;
+  let requireManualApprovalForCurrentSubmit = true;
+  let currentCommittedSha = '';
+  let currentRepoForSubmit = '';
+  let xDraftData: {
+    commitSha: string;
+    thread: { main: string; replies: string[] };
+    meta?: Record<string, any>;
+  } | null = null;
 
   const WORKFLOW_TRACKING_KEY = 'nlp_paper_news_admin_workflow_tracking_v1';
+  const X_HARD_LIMIT = 280;
+  const URL_REGEX = /https?:\/\/[^\s)]+/gi;
+
+  function utf8ToBase64(str: string) {
+    return btoa(unescape(encodeURIComponent(str)));
+  }
+
+  function base64ToUtf8(str: string) {
+    return decodeURIComponent(escape(atob(str)));
+  }
+
+  function countXChars(text: string) {
+    const normalized = String(text || '').replace(URL_REGEX, 'x'.repeat(23));
+    const codepoint = Array.from(normalized).length;
+    try {
+      const seg = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+      const grapheme = Array.from(seg.segment(normalized)).length;
+      return Math.max(codepoint, grapheme);
+    } catch {
+      return codepoint;
+    }
+  }
 
   // ─── Type colors ───────────────────────
   const TYPE_COLORS: Record<string, { border: string; bg: string; text: string }> = {
@@ -707,6 +764,87 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     }
   }
 
+  function validateThreadLimit(main: string, replies: string[]) {
+    const failures: { phase: string; used: number }[] = [];
+    const mainChars = countXChars(main);
+    if (mainChars > X_HARD_LIMIT) failures.push({ phase: 'main', used: mainChars });
+    replies.forEach((r, idx) => {
+      const used = countXChars(r);
+      if (used > X_HARD_LIMIT) failures.push({ phase: `reply ${idx + 1}`, used });
+    });
+    return failures;
+  }
+
+  function collectEditedThread() {
+    const mainInput = document.getElementById('x-main-input') as HTMLTextAreaElement | null;
+    if (!mainInput) return null;
+    const replyInputs = [...document.querySelectorAll('.x-reply-input')] as HTMLTextAreaElement[];
+    return {
+      main: mainInput.value.trim(),
+      replies: replyInputs.map((el) => el.value.trim()),
+    };
+  }
+
+  function bindXCountIndicators() {
+    const mainInput = document.getElementById('x-main-input') as HTMLTextAreaElement | null;
+    const mainCount = document.getElementById('x-main-count');
+    if (mainInput && mainCount) {
+      const updateMain = () => {
+        const used = countXChars(mainInput.value);
+        mainCount.textContent = `${used}/${X_HARD_LIMIT}`;
+        mainCount.className = `mt-1 text-xs font-mono ${used > X_HARD_LIMIT ? 'text-red-500' : 'text-gray-400'}`;
+      };
+      mainInput.addEventListener('input', updateMain);
+      updateMain();
+    }
+
+    const replies = [...document.querySelectorAll('.x-reply-input')] as HTMLTextAreaElement[];
+    replies.forEach((el) => {
+      const countEl = document.getElementById(`x-reply-count-${el.dataset.index}`);
+      const update = () => {
+        const used = countXChars(el.value);
+        if (countEl) {
+          countEl.textContent = `${used}/${X_HARD_LIMIT}`;
+          countEl.className = `text-xs font-mono ${used > X_HARD_LIMIT ? 'text-red-500' : 'text-gray-400'}`;
+        }
+      };
+      el.addEventListener('input', update);
+      update();
+    });
+  }
+
+  function showXDraftReview(draft: { commitSha: string; thread: { main: string; replies: string[] }; meta?: Record<string, any> }) {
+    xDraftData = draft;
+    const section = document.getElementById('x-review-section');
+    const mainInput = document.getElementById('x-main-input') as HTMLTextAreaElement | null;
+    const repliesEditor = document.getElementById('x-replies-editor');
+    const metaEl = document.getElementById('x-review-meta');
+    const noteEl = document.getElementById('x-review-note');
+
+    if (!section || !mainInput || !repliesEditor) return;
+    section.classList.remove('hidden');
+    mainInput.value = draft.thread.main || '';
+
+    const mainModel = draft.meta?.main_model || '-';
+    const replyModel = draft.meta?.reply_model || '-';
+    if (metaEl) metaEl.textContent = `main 모델: ${mainModel} · reply 모델: ${replyModel}`;
+    if (noteEl) noteEl.textContent = '문안을 직접 수정한 뒤 승인 게시할 수 있습니다.';
+
+    repliesEditor.innerHTML = (draft.thread.replies || []).map((reply, idx) => `
+      <div>
+        <label class="block text-xs text-gray-500 mb-1">Reply ${idx + 1}</label>
+        <textarea
+          data-index="${idx + 1}"
+          class="x-reply-input w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"
+          rows="3"
+        >${escapeHtml(reply)}</textarea>
+        <div id="x-reply-count-${idx + 1}" class="text-xs font-mono text-gray-400">0/280</div>
+      </div>
+    `).join('');
+
+    bindXCountIndicators();
+  }
+
   // Clear preview
   document.getElementById('clear-preview')?.addEventListener('click', () => {
     parsedItems = [];
@@ -901,8 +1039,10 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       setSubmitLoading(false);
 
       // Start workflow polling
-      showStatus(`✅ 커밋 완료${skippedMsg} · ${shortSha}\n⏳ X 포스팅 워크플로 대기 중...`, 'info');
-      startWorkflowTracking(repo, token, newCommit.sha, newItems.length);
+      showStatus(`✅ 커밋 완료${skippedMsg} · ${shortSha}\n⏳ X 초안 생성 워크플로 대기 중...`, 'info');
+      currentCommittedSha = newCommit.sha;
+      currentRepoForSubmit = repo;
+      startWorkflowTracking(repo, token, newCommit.sha, newItems.length, undefined, requireManualApprovalForCurrentSubmit);
     } catch (err: any) {
       showStatus(`오류: ${err.message}`, 'error');
       setSubmitLoading(false);
@@ -918,6 +1058,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     commitSha: string;
     startedAt: number;
     expectedReplies: number;
+    requireManualApproval?: boolean;
   };
 
   type LivePostProgress = {
@@ -942,6 +1083,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         commitSha: String(parsed.commitSha),
         startedAt: Number(parsed.startedAt),
         expectedReplies: Number(parsed.expectedReplies || 0),
+        requireManualApproval: parsed.requireManualApproval !== false,
       };
     } catch {
       return null;
@@ -953,12 +1095,13 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     hasActiveWorkflowTracking = false;
   }
 
-  function startWorkflowTracking(repo: string, token: string, commitSha: string, expectedReplies: number, startedAt?: number) {
+  function startWorkflowTracking(repo: string, token: string, commitSha: string, expectedReplies: number, startedAt?: number, requireManualApproval = true) {
     const state: WorkflowTrackingState = {
       repo,
       commitSha,
       startedAt: startedAt || Date.now(),
       expectedReplies: Math.max(0, expectedReplies || 0),
+      requireManualApproval,
     };
     hasActiveWorkflowTracking = true;
     saveWorkflowTracking(state);
@@ -990,6 +1133,60 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     return { postingReply, totalReplies, postedReplies, degraded };
   }
 
+  async function fetchPrepareDraftPayload(repo: string, token: string, jobId: number) {
+    const res = await fetch(`https://api.github.com/repos/${repo}/actions/jobs/${jobId}/logs`, {
+      headers: { 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json' }
+    });
+    if (!res.ok) return null;
+    const text = await res.text();
+    const match = text.match(/X_DRAFT_PAYLOAD_BASE64=([A-Za-z0-9+/=]+)/);
+    if (!match?.[1]) return null;
+    try {
+      return JSON.parse(base64ToUtf8(match[1]));
+    } catch {
+      return null;
+    }
+  }
+
+  async function dispatchApprovedPost(repo: string, token: string, commitSha: string, approvalMode: 'manual_approved' | 'one_time_auto') {
+    const thread = collectEditedThread();
+    if (!thread) {
+      showStatus('X 초안을 불러오지 못했습니다.', 'error');
+      return;
+    }
+
+    const failures = validateThreadLimit(thread.main, thread.replies);
+    if (failures.length > 0) {
+      const msg = failures.map((f) => `${f.phase} ${f.used}/${X_HARD_LIMIT}`).join(', ');
+      showStatus(`길이 제한 초과: ${msg}`, 'error', { autoScroll: true });
+      return;
+    }
+
+    const body = {
+      ref: 'main',
+      inputs: {
+        commit_sha: commitSha,
+        approval_mode: approvalMode,
+        thread_json_b64: utf8ToBase64(JSON.stringify(thread)),
+      }
+    };
+
+    const dispatchRes = await fetch(`https://api.github.com/repos/${repo}/actions/workflows/post-approved.yml/dispatches`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `token ${token}`,
+        'Accept': 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!dispatchRes.ok) {
+      const err = await dispatchRes.text();
+      throw new Error(`승인 게시 워크플로우 실행 실패 (${dispatchRes.status}): ${err}`);
+    }
+  }
+
   async function pollWorkflowStatus(repo: string, token: string, commitSha: string, state?: WorkflowTrackingState) {
     const shortSha = commitSha.slice(0, 7);
     const POLL_INTERVAL = 5000;
@@ -1009,13 +1206,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     const currentSession = pollSessionId;
 
     let polls = 0;
-    let postStartedAt = 0;
-    let liveProgress: LivePostProgress | null = null;
-    let logFetchDisabled = false;
-    let lastLogFetchAt = 0;
-
     const elapsedSeconds = () => Math.max(0, Math.floor((Date.now() - trackingState.startedAt) / 1000));
-    const postElapsedSeconds = () => Math.max(0, Math.floor((Date.now() - postStartedAt) / 1000));
     const isCurrentSession = () => currentSession === pollSessionId;
     const scheduleNext = () => {
       if (!isCurrentSession()) return;
@@ -1028,47 +1219,6 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       });
       if (!res.ok) return null;
       return res.json();
-    }
-
-    async function maybeUpdateLiveProgress(postJobId?: number) {
-      if (!postJobId || logFetchDisabled) return;
-      const now = Date.now();
-      if (now - lastLogFetchAt < 10000) return; // 10s 마다 로그 파싱
-      lastLogFetchAt = now;
-
-      try {
-        const progress = await fetchPostJobProgress(repo, token, postJobId);
-        if (progress) liveProgress = progress;
-      } catch (e: any) {
-        const msg = String(e?.message || '');
-        if (msg.includes('log-fetch-403') || msg.includes('log-fetch-404')) {
-          // 토큰 권한/엔드포인트 접근 불가 시 과도한 재시도 중단
-          logFetchDisabled = true;
-        }
-      }
-    }
-
-    function buildPostProgressMessage() {
-      if (liveProgress?.degraded) {
-        return '⚠️ reply 차단 감지: main-only 처리 중...';
-      }
-
-      const total = liveProgress?.totalReplies || trackingState.expectedReplies || 0;
-      if (liveProgress?.postingReply && total > 0) {
-        return `🐦 X reply ${liveProgress.postingReply}/${total} 게시 중...`;
-      }
-
-      if (liveProgress?.postedReplies && total > 0) {
-        const next = Math.min(total, liveProgress.postedReplies + 1);
-        return `🐦 X reply ${next}/${total} 게시 준비 중...`;
-      }
-
-      if (total > 0 && postStartedAt > 0) {
-        const estimated = Math.min(total, Math.max(1, Math.floor(postElapsedSeconds() / 11) + 1));
-        return `🐦 X 스레드 게시 중... (reply ${estimated}/${total} 예상)`;
-      }
-
-      return '🐦 X 스레드 게시 중...';
     }
 
     async function poll() {
@@ -1100,24 +1250,39 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         if (runStatus === 'completed') {
           clearWorkflowTracking();
           const jobsData = await ghApi(`runs/${run.id}/jobs`);
-          const postJob = jobsData?.jobs?.find((j: any) => j.name === 'post_x');
+          const prepareJob = jobsData?.jobs?.find((j: any) => j.name === 'prepare');
 
           if (runConclusion === 'success') {
-            if (postJob?.conclusion === 'success') {
-              showStatus(`✅ 커밋 완료 · ${shortSha}\n✅ X 포스팅 성공! 스레드가 게시되었습니다.`, 'success');
-              fadeStatusAfter(7000);
-            } else if (postJob?.conclusion === 'skipped') {
-              showStatus(`✅ 커밋 완료 · ${shortSha}\n⏭️ X 포스팅 건너뜀 (ENABLE_X_POST 미설정 또는 새 항목 없음)`, 'info');
-              fadeStatusAfter(7000);
+            const draftPayload = prepareJob?.id
+              ? await fetchPrepareDraftPayload(repo, token, prepareJob.id)
+              : null;
+
+            if (draftPayload?.thread?.main) {
+              const draft = {
+                commitSha,
+                thread: {
+                  main: String(draftPayload.thread.main || ''),
+                  replies: Array.isArray(draftPayload.thread.replies) ? draftPayload.thread.replies.map((x: any) => String(x || '')) : [],
+                },
+                meta: draftPayload.meta || {},
+              };
+
+              currentCommittedSha = commitSha;
+              currentRepoForSubmit = repo;
+              showXDraftReview(draft);
+
+              if (trackingState.requireManualApproval === false) {
+                showStatus(`✅ 커밋 완료 · ${shortSha}\n🤖 자동 승인 모드로 X 게시를 시작합니다...`, 'info', { autoScroll: true });
+                await dispatchApprovedPost(repo, token, commitSha, 'one_time_auto');
+                await pollApprovedPostStatus(repo, token, commitSha, Date.now());
+              } else {
+                showStatus(`✅ 커밋 완료 · ${shortSha}\n📝 X 초안이 준비되었습니다. 문안을 확인한 뒤 승인해 주세요.`, 'success', { autoScroll: true });
+              }
             } else {
-              showStatus(`✅ 커밋 완료 · ${shortSha}\n✅ 워크플로 완료`, 'success');
-              fadeStatusAfter(7000);
+              showStatus(`✅ 커밋 완료 · ${shortSha}\n⚠️ X 초안을 찾지 못했습니다. Actions에서 notify-artifacts를 확인하세요.`, 'warn');
             }
           } else {
-            const failMsg = postJob?.conclusion === 'failure'
-              ? 'X 포스팅 실패 — Actions에서 상세 로그를 확인하세요.'
-              : `워크플로 ${runConclusion || '실패'}`;
-            showStatus(`✅ 커밋 완료 · ${shortSha}\n❌ ${failMsg}`, 'error');
+            showStatus(`✅ 커밋 완료 · ${shortSha}\n❌ 워크플로 ${runConclusion || '실패'}`, 'error');
           }
           return;
         }
@@ -1126,17 +1291,12 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         const jobs = jobsData?.jobs || [];
         const activeJob = jobs.find((j: any) => j.status === 'in_progress');
         const activeStep = activeJob?.steps?.find((s: any) => s.status === 'in_progress');
-        const postJob = jobs.find((j: any) => j.name === 'post_x');
 
         let progressMsg = '';
         if (activeJob?.name === 'prepare') {
           progressMsg = '📦 데이터 준비 중...';
           if (activeStep?.name?.includes('Build digest')) progressMsg = '📦 포스트 생성 중...';
           else if (activeStep?.name?.includes('Extract')) progressMsg = '📦 새 항목 추출 중...';
-        } else if (activeJob?.name === 'post_x') {
-          if (!postStartedAt) postStartedAt = Date.now();
-          await maybeUpdateLiveProgress(postJob?.id);
-          progressMsg = buildPostProgressMessage();
         } else if (jobs.every((j: any) => j.status === 'queued')) {
           progressMsg = '⏳ 워크플로 실행 대기 중...';
         } else {
@@ -1152,6 +1312,82 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     }
 
     poll();
+  }
+
+  async function pollApprovedPostStatus(repo: string, token: string, commitSha: string, dispatchedAt: number) {
+    const shortSha = commitSha.slice(0, 7);
+    const POLL_INTERVAL = 5000;
+    const MAX_POLLS = 96;
+    let polls = 0;
+    let liveProgress: LivePostProgress | null = null;
+    let lastLogFetchAt = 0;
+
+    async function fetchWorkflowRuns() {
+      const res = await fetch(`https://api.github.com/repos/${repo}/actions/workflows/post-approved.yml/runs?per_page=10`, {
+        headers: { 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json' }
+      });
+      if (!res.ok) return null;
+      return res.json();
+    }
+
+    async function fetchJobs(runId: number) {
+      const res = await fetch(`https://api.github.com/repos/${repo}/actions/runs/${runId}/jobs`, {
+        headers: { 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json' }
+      });
+      if (!res.ok) return null;
+      return res.json();
+    }
+
+    return new Promise<void>((resolve) => {
+      const tick = async () => {
+        polls++;
+        if (polls > MAX_POLLS) {
+          showStatus(`✅ 커밋 완료 · ${shortSha}\n⚠️ 승인 게시 상태 확인 시간 초과 — Actions에서 확인하세요.`, 'warn');
+          resolve();
+          return;
+        }
+
+        const runsData = await fetchWorkflowRuns();
+        const runs = runsData?.workflow_runs || [];
+        const run = runs.find((r: any) => Date.parse(r.created_at || '') >= (dispatchedAt - 30000));
+        if (!run) {
+          showStatus(`✅ 커밋 완료 · ${shortSha}\n⏳ 승인 게시 워크플로 시작 대기 중...`, 'info');
+          setTimeout(tick, POLL_INTERVAL);
+          return;
+        }
+
+        const jobsData = await fetchJobs(run.id);
+        const postJob = jobsData?.jobs?.find((j: any) => j.name === 'post_x');
+
+        if (postJob?.status === 'in_progress' && Date.now() - lastLogFetchAt > 10000) {
+          lastLogFetchAt = Date.now();
+          if (postJob?.id) {
+            const progress = await fetchPostJobProgress(repo, token, postJob.id).catch(() => null);
+            if (progress) liveProgress = progress;
+          }
+        }
+
+        if (run.status === 'completed') {
+          if (run.conclusion === 'success') {
+            showStatus(`✅ 커밋 완료 · ${shortSha}\n✅ X 포스팅 성공!`, 'success', { autoScroll: true });
+            fadeStatusAfter(7000);
+          } else {
+            const degraded = liveProgress?.degraded ? '\n⚠️ reply 차단(main-only) 가능성: Actions 로그를 확인하세요.' : '';
+            showStatus(`✅ 커밋 완료 · ${shortSha}\n❌ X 포스팅 실패${degraded}`, 'error', { autoScroll: true });
+          }
+          resolve();
+          return;
+        }
+
+        if (liveProgress?.postingReply && liveProgress?.totalReplies) {
+          showStatus(`✅ 커밋 완료 · ${shortSha}\n🐦 X reply ${liveProgress.postingReply}/${liveProgress.totalReplies} 게시 중...`, 'info');
+        } else {
+          showStatus(`✅ 커밋 완료 · ${shortSha}\n🐦 승인된 문안으로 X 게시 중...`, 'info');
+        }
+        setTimeout(tick, POLL_INTERVAL);
+      };
+      tick();
+    });
   }
 
   function fadeStatusAfter(ms: number) {
@@ -1202,6 +1438,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         return `<div class="flex items-center gap-1.5"><span>${icon}</span><span class="truncate">${escapeHtml(item.title)}</span></div>`;
       }).join('');
     }
+    const approvalEl = document.getElementById('confirm-manual-approval') as HTMLInputElement | null;
+    if (approvalEl) approvalEl.checked = true;
     modal.classList.remove('hidden');
   }
 
@@ -1225,6 +1463,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   });
 
   document.getElementById('confirm-submit')?.addEventListener('click', () => {
+    const approvalEl = document.getElementById('confirm-manual-approval') as HTMLInputElement | null;
+    requireManualApprovalForCurrentSubmit = approvalEl ? approvalEl.checked : true;
     closeConfirmModal();
     if (pendingSubmitItems.length > 0) {
       submitToGitHub(pendingSubmitItems);
@@ -1243,6 +1483,38 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       navigator.clipboard.writeText(jsonOutput.textContent || '');
       showToast('JSON이 클립보드에 복사되었습니다');
     }
+  });
+
+  document.getElementById('x-approve-post-btn')?.addEventListener('click', async () => {
+    const token = localStorage.getItem('github_token');
+    if (!token) {
+      showStatus('GitHub 토큰이 필요합니다.', 'error');
+      return;
+    }
+    if (!xDraftData || !currentCommittedSha || !currentRepoForSubmit) {
+      showStatus('승인할 X 초안이 없습니다. 먼저 항목을 커밋해 주세요.', 'warn');
+      return;
+    }
+
+    try {
+      showStatus(`✅ 커밋 완료 · ${currentCommittedSha.slice(0, 7)}\n⏳ 승인 게시 워크플로 실행 중...`, 'info');
+      await dispatchApprovedPost(currentRepoForSubmit, token, currentCommittedSha, 'manual_approved');
+      await pollApprovedPostStatus(currentRepoForSubmit, token, currentCommittedSha, Date.now());
+    } catch (err: any) {
+      showStatus(`승인 게시 실행 실패: ${err.message}`, 'error');
+    }
+  });
+
+  document.getElementById('x-copy-thread-btn')?.addEventListener('click', async () => {
+    const thread = collectEditedThread();
+    if (!thread) return;
+    const text = [
+      '=== MAIN ===',
+      thread.main,
+      ...thread.replies.flatMap((r, i) => ['', `=== REPLY ${i + 1} ===`, r]),
+    ].join('\n');
+    await navigator.clipboard.writeText(text);
+    showToast('X 스레드가 클립보드에 복사되었습니다');
   });
 
   // ─── GitHub token ──────────────────────
@@ -1308,7 +1580,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     }
 
     showStatus(`🔄 이전 워크플로 상태 복구 중... · ${state.commitSha.slice(0, 7)}`, 'info');
-    startWorkflowTracking(state.repo, token, state.commitSha, state.expectedReplies, state.startedAt);
+    startWorkflowTracking(state.repo, token, state.commitSha, state.expectedReplies, state.startedAt, state.requireManualApproval !== false);
   }
 
   window.addEventListener('beforeunload', (e) => {

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -224,47 +224,63 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       </div>
 
       <div class="space-y-3">
-        <div>
+        <div class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid">
           <div class="flex items-center justify-between mb-1">
             <label class="block text-xs text-gray-500">Main post</label>
-            <button id="x-main-approve-btn" class="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400">main 승인</button>
+            <div class="flex items-center gap-1.5">
+              <button id="x-copy-main-btn" class="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400 inline-flex items-center gap-1" title="main 복사">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16h8m-8-4h8m2 8H6a2 2 0 01-2-2V6a2 2 0 012-2h8l6 6v8a2 2 0 01-2 2z"/></svg>
+                복사
+              </button>
+              <button id="x-main-approve-btn" class="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400">main 승인</button>
+            </div>
           </div>
           <textarea id="x-main-input" rows="4" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"></textarea>
           <div id="x-main-count" class="mt-1 text-xs text-gray-400 font-mono">0/280</div>
         </div>
-        <div>
+        <div class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid">
           <div class="flex items-center justify-between mb-1">
             <label class="block text-xs text-gray-500">Replies</label>
-            <button id="x-replies-approve-btn" class="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400">replies 승인</button>
+            <div class="flex items-center gap-1.5">
+              <button id="x-copy-replies-btn" class="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400 inline-flex items-center gap-1" title="replies 복사">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16h8m-8-4h8m2 8H6a2 2 0 01-2-2V6a2 2 0 012-2h8l6 6v8a2 2 0 01-2 2z"/></svg>
+                복사
+              </button>
+              <button id="x-replies-approve-btn" class="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400">replies 승인</button>
+            </div>
           </div>
           <div id="x-replies-editor" class="space-y-2"></div>
         </div>
       </div>
 
-      <div class="mt-4 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid">
-        <label class="block text-xs text-gray-500 mb-2">AI 피드백 반영</label>
-        <div class="space-y-3">
-          <div>
+      <details class="mt-4 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid">
+        <summary class="text-sm font-semibold text-gray-700 dark:text-gray-200 cursor-pointer">AI로 텍스트 다듬기 (선택)</summary>
+        <div class="mt-3 space-y-3">
+          <div class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-anthro-darkSurface">
             <label class="block text-xs text-gray-500 mb-1">Main instruction</label>
             <textarea id="x-ai-main-instruction" rows="2" placeholder="예: main을 더 간결하고 임팩트 있게 정리해줘."
-              class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-anthro-darkSurface text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"></textarea>
-            <button id="x-ai-main-rewrite-btn" class="mt-1 px-3 py-1.5 rounded-md border border-gray-200 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-300 hover:border-claude-400 transition-all">main만 AI 수정</button>
+              class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"></textarea>
+            <div class="mt-2">
+              <button id="x-ai-main-rewrite-btn" class="px-3 py-1.5 rounded-md border border-gray-200 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-300 hover:border-claude-400 transition-all">main만 AI 수정</button>
+            </div>
           </div>
-          <div>
+          <div class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-anthro-darkSurface">
             <div class="flex items-center gap-2 mb-1">
               <label class="text-xs text-gray-500">Reply target</label>
-              <select id="x-ai-reply-target" class="px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-anthro-darkSurface text-xs">
+              <select id="x-ai-reply-target" class="px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid text-xs">
                 <option value="all">전체 replies</option>
               </select>
             </div>
             <textarea id="x-ai-reply-instruction" rows="2" placeholder="예: reply 2는 실무 적용 관점으로 다시 써줘."
-              class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-anthro-darkSurface text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"></textarea>
-            <button id="x-ai-reply-rewrite-btn" class="mt-1 px-3 py-1.5 rounded-md border border-gray-200 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-300 hover:border-claude-400 transition-all">reply AI 수정</button>
+              class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"></textarea>
+            <div class="mt-2">
+              <button id="x-ai-reply-rewrite-btn" class="px-3 py-1.5 rounded-md border border-gray-200 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-300 hover:border-claude-400 transition-all">reply AI 수정</button>
+            </div>
           </div>
         </div>
         <div class="mt-2 text-xs text-gray-400" id="x-ai-status"></div>
         <div id="x-ai-history" class="mt-2 space-y-1 text-xs text-gray-500 dark:text-gray-400"></div>
-      </div>
+      </details>
 
       <div class="mt-4 flex flex-wrap gap-2">
         <button id="x-approve-post-btn" class="px-4 py-2 rounded-lg bg-claude-500 text-white text-sm font-semibold hover:bg-claude-600 transition-all">전체 승인 후 X 게시</button>
@@ -280,14 +296,15 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         <div class="animate-fade-in-up relative max-w-md w-full bg-white dark:bg-anthro-darkSurface rounded-2xl border border-gray-200 dark:border-gray-800 shadow-xl p-6">
           <h3 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3">항목 추가 확인</h3>
           <p id="confirm-message" class="text-sm text-gray-600 dark:text-gray-300 mb-2"></p>
-          <div id="confirm-item-list" class="mb-4 max-h-40 overflow-y-auto text-xs text-gray-500 dark:text-gray-400 space-y-1"></div>
-          <label class="mb-4 flex items-start gap-2 text-xs text-gray-600 dark:text-gray-300">
+          <div id="confirm-item-list" class="mb-3 max-h-40 overflow-y-auto text-xs text-gray-500 dark:text-gray-400 space-y-1"></div>
+          <div class="border-t border-gray-200 dark:border-gray-700 my-3"></div>
+          <label class="mb-4 flex items-start gap-2 text-xs text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-anthro-darkMid px-3 py-2 rounded-lg">
             <input type="checkbox" id="confirm-manual-approval" class="mt-0.5 accent-claude-500" checked />
-            <span>X 게시 전 draft 확인/수정 후 승인하기 (기본)</span>
+            <span>X 게시 전에 draft를 확인하고 직접 승인할게요</span>
           </label>
           <div class="flex gap-2">
             <button id="confirm-cancel" class="flex-1 px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all">취소</button>
-            <button id="confirm-submit" class="flex-1 px-4 py-2.5 rounded-lg bg-claude-500 text-white text-sm font-semibold hover:bg-claude-600 transition-all">추가 실행</button>
+            <button id="confirm-submit" class="flex-1 px-4 py-2.5 rounded-lg bg-claude-500 text-white text-sm font-semibold hover:bg-claude-600 transition-all">확인</button>
           </div>
         </div>
       </div>
@@ -322,11 +339,20 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
   const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+  function isLocalDevHost() {
+    const host = window.location.hostname;
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1';
+  }
+
   function isMockMode() {
-    return localStorage.getItem(MOCK_MODE_KEY) === 'true';
+    return isLocalDevHost() && localStorage.getItem(MOCK_MODE_KEY) === 'true';
   }
 
   function setMockMode(enabled: boolean) {
+    if (!isLocalDevHost()) {
+      localStorage.removeItem(MOCK_MODE_KEY);
+      return;
+    }
     localStorage.setItem(MOCK_MODE_KEY, enabled ? 'true' : 'false');
   }
 
@@ -864,6 +890,12 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     };
   }
 
+  function mockRewriteText(base: string, instruction: string) {
+    const brief = instruction.replace(/\s+/g, ' ').trim().slice(0, 40);
+    const cleaned = base.replace(/\[AI edit[^\]]*\]/g, '').trim();
+    return clipToXLimit(`[mock rewrite] ${brief}\n${cleaned}`);
+  }
+
   function collectEditedThread() {
     const mainInput = document.getElementById('x-main-input') as HTMLTextAreaElement | null;
     if (!mainInput) return null;
@@ -914,11 +946,11 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
     if (mainBtn) {
       mainBtn.textContent = xMainApproved ? 'main 승인됨' : 'main 승인';
-      mainBtn.className = `text-xs px-2 py-1 rounded-md border ${xMainApproved ? 'border-emerald-300 text-emerald-600' : 'border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400'}`;
+      mainBtn.className = `text-xs px-2 py-1 rounded-md border ${xMainApproved ? 'border-claude-300 text-claude-600 bg-claude-50 dark:bg-claude-950/20' : 'border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400'}`;
     }
     if (repliesBtn) {
       repliesBtn.textContent = xRepliesApproved ? 'replies 승인됨' : 'replies 승인';
-      repliesBtn.className = `text-xs px-2 py-1 rounded-md border ${xRepliesApproved ? 'border-emerald-300 text-emerald-600' : 'border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400'}`;
+      repliesBtn.className = `text-xs px-2 py-1 rounded-md border ${xRepliesApproved ? 'border-claude-300 text-claude-600 bg-claude-50 dark:bg-claude-950/20' : 'border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400'}`;
     }
     if (postBtn) {
       const enabled = xMainApproved && xRepliesApproved;
@@ -1866,16 +1898,15 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       if (statusEl) statusEl.textContent = `${target === 'main' ? 'main' : 'reply'} AI 수정 요청 중...`;
 
       if (mockMode) {
-        const append = (base: string) => clipToXLimit(`${base}\n\n[AI edit] ${instruction}`);
         if (target === 'main') {
-          nextThread.main = append(nextThread.main);
+          nextThread.main = mockRewriteText(nextThread.main, instruction);
           xMainApproved = false;
         } else if (replyTarget === 'all') {
-          nextThread.replies = nextThread.replies.map((r) => append(r));
+          nextThread.replies = nextThread.replies.map((r) => mockRewriteText(r, instruction));
           xRepliesApproved = false;
         } else {
           const idx = replyTarget - 1;
-          if (nextThread.replies[idx]) nextThread.replies[idx] = append(nextThread.replies[idx]);
+          if (nextThread.replies[idx]) nextThread.replies[idx] = mockRewriteText(nextThread.replies[idx], instruction);
           xRepliesApproved = false;
         }
       } else {
@@ -1954,6 +1985,21 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     ].join('\n');
     await navigator.clipboard.writeText(text);
     showToast('X 스레드가 클립보드에 복사되었습니다');
+  });
+
+  document.getElementById('x-copy-main-btn')?.addEventListener('click', async () => {
+    const thread = collectEditedThread();
+    if (!thread) return;
+    await navigator.clipboard.writeText(thread.main || '');
+    showToast('main post를 복사했습니다');
+  });
+
+  document.getElementById('x-copy-replies-btn')?.addEventListener('click', async () => {
+    const thread = collectEditedThread();
+    if (!thread) return;
+    const text = thread.replies.map((r, i) => `=== REPLY ${i + 1} ===\n${r}`).join('\n\n');
+    await navigator.clipboard.writeText(text);
+    showToast('replies를 복사했습니다');
   });
 
   // ─── GitHub token ──────────────────────
@@ -2040,10 +2086,23 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   });
 
   // ─── Init ──────────────────────────────
+  if (!isLocalDevHost()) {
+    setMockMode(false);
+  }
   updateTokenStatus();
   const mockModeToggle = document.getElementById('mock-mode-toggle') as HTMLInputElement | null;
   if (mockModeToggle) {
-    mockModeToggle.checked = isMockMode();
+    if (!isLocalDevHost()) {
+      mockModeToggle.checked = false;
+      mockModeToggle.disabled = true;
+      mockModeToggle.closest('label')?.classList.add('opacity-50', 'pointer-events-none');
+      const hint = document.createElement('div');
+      hint.className = 'mt-1 text-[11px] text-gray-400';
+      hint.textContent = 'mock 모드는 로컬 개발 서버(localhost)에서만 사용할 수 있습니다.';
+      mockModeToggle.closest('label')?.parentElement?.appendChild(hint);
+    } else {
+      mockModeToggle.checked = isMockMode();
+    }
   }
   const savedRepo = localStorage.getItem('github_repo');
   if (savedRepo) {

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -331,6 +331,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   let xMainApproved = false;
   let xRepliesApproved = false;
   let xAiHistory: Array<{ at: string; target: string; instruction: string; model: string; summary: string }> = [];
+  let isPostingInProgress = false;
+  let isAiRewriteInProgress = false;
 
   const WORKFLOW_TRACKING_KEY = 'nlp_paper_news_admin_workflow_tracking_v1';
   const MOCK_MODE_KEY = 'nlp_paper_news_admin_mock_mode_v1';
@@ -865,6 +867,45 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     return '';
   }
 
+  function extractCoreText(base: string) {
+    return String(base || '')
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .filter((s) => !s.startsWith('http'))
+      .slice(0, 2)
+      .join(' / ');
+  }
+
+  function summarizeInstruction(instruction: string) {
+    return instruction
+      .replace(/\[target:[^\]]+\]/gi, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 34);
+  }
+
+  function mockRewriteMain(base: string, instruction: string) {
+    const core = extractCoreText(base);
+    const intent = summarizeInstruction(instruction);
+    const lines = [
+      `📌 핵심 업데이트`,
+      core || '이번 업데이트 요약',
+      `- 요청 반영: ${intent || '톤/구조 조정'}`,
+    ];
+    return clipToXLimit(lines.join('\n'));
+  }
+
+  function mockRewriteReply(base: string, instruction: string, idx: number) {
+    const core = extractCoreText(base);
+    const intent = summarizeInstruction(instruction);
+    const lines = [
+      `${idx + 1}) ${core || '업데이트 상세'}`,
+      `포인트: ${intent || '핵심 설명 보강'}`,
+    ];
+    return clipToXLimit(lines.join('\n'));
+  }
+
   function buildMockDraft(items: any[], commitSha: string) {
     const titles = items.slice(0, 3).map((i) => i.title).join(' · ');
     const mainBase = `📌 이번 업데이트 ${items.length}건\n${titles}${items.length > 3 ? ` 외 ${items.length - 3}건` : ''}`;
@@ -888,12 +929,6 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         reply_model: 'mock-local',
       }
     };
-  }
-
-  function mockRewriteText(base: string, instruction: string) {
-    const brief = instruction.replace(/\s+/g, ' ').trim().slice(0, 40);
-    const cleaned = base.replace(/\[AI edit[^\]]*\]/g, '').trim();
-    return clipToXLimit(`[mock rewrite] ${brief}\n${cleaned}`);
   }
 
   function collectEditedThread() {
@@ -954,9 +989,14 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     }
     if (postBtn) {
       const enabled = xMainApproved && xRepliesApproved;
-      postBtn.disabled = !enabled;
-      postBtn.classList.toggle('opacity-50', !enabled);
-      postBtn.classList.toggle('cursor-not-allowed', !enabled);
+      postBtn.disabled = !enabled || isPostingInProgress;
+      postBtn.classList.toggle('opacity-50', !enabled || isPostingInProgress);
+      postBtn.classList.toggle('cursor-not-allowed', !enabled || isPostingInProgress);
+      if (isPostingInProgress) {
+        postBtn.textContent = '게시 진행 중...';
+      } else {
+        postBtn.textContent = '전체 승인 후 X 게시';
+      }
     }
     if (noteEl) {
       noteEl.textContent = (xMainApproved && xRepliesApproved)
@@ -1422,6 +1462,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
     if (!dispatchRes.ok) {
       const err = await dispatchRes.text();
+      if (dispatchRes.status === 404) throw new Error('승인 게시 워크플로우를 찾지 못했습니다. 브랜치/파일 상태를 확인해 주세요.');
+      if (dispatchRes.status === 403) throw new Error('workflow 실행 권한이 부족합니다. 토큰 scope를 확인해 주세요 (repo/workflow).');
       throw new Error(`승인 게시 워크플로우 실행 실패 (${dispatchRes.status}): ${err}`);
     }
   }
@@ -1448,6 +1490,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     });
     if (!dispatchRes.ok) {
       const err = await dispatchRes.text();
+      if (dispatchRes.status === 404) throw new Error('AI 수정 워크플로우를 찾지 못했습니다. 브랜치/파일 상태를 확인해 주세요.');
+      if (dispatchRes.status === 403) throw new Error('AI 수정 워크플로우 실행 권한이 부족합니다. 토큰 scope를 확인해 주세요 (repo/workflow).');
       throw new Error(`AI 수정 워크플로우 실행 실패 (${dispatchRes.status}): ${err}`);
     }
   }
@@ -1843,8 +1887,11 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       showStatus('게시 전 main과 replies를 각각 승인해 주세요.', 'warn');
       return;
     }
+    if (isPostingInProgress) return;
 
     try {
+      isPostingInProgress = true;
+      updateReviewApprovalUi();
       if (mockMode) {
         await runMockPostFlow(currentCommittedSha);
       } else {
@@ -1854,6 +1901,9 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       }
     } catch (err: any) {
       showStatus(`승인 게시 실행 실패: ${err.message}`, 'error');
+    } finally {
+      isPostingInProgress = false;
+      updateReviewApprovalUi();
     }
   });
 
@@ -1879,6 +1929,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       showToast('instruction을 입력해 주세요.');
       return;
     }
+    if (isAiRewriteInProgress) return;
 
     const scopedInstruction = target === 'main'
       ? `[target: main only]\n${instruction}`
@@ -1887,6 +1938,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       : `[target: reply ${replyTarget} only; keep others]\n${instruction}`;
 
     try {
+      isAiRewriteInProgress = true;
       const current = collectEditedThread();
       if (!current) throw new Error('현재 thread를 읽지 못했습니다.');
 
@@ -1899,20 +1951,22 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
       if (mockMode) {
         if (target === 'main') {
-          nextThread.main = mockRewriteText(nextThread.main, instruction);
+          nextThread.main = mockRewriteMain(nextThread.main, instruction);
           xMainApproved = false;
         } else if (replyTarget === 'all') {
-          nextThread.replies = nextThread.replies.map((r) => mockRewriteText(r, instruction));
+          nextThread.replies = nextThread.replies.map((r, i) => mockRewriteReply(r, instruction, i));
           xRepliesApproved = false;
         } else {
           const idx = replyTarget - 1;
-          if (nextThread.replies[idx]) nextThread.replies[idx] = mockRewriteText(nextThread.replies[idx], instruction);
+          if (nextThread.replies[idx]) nextThread.replies[idx] = mockRewriteReply(nextThread.replies[idx], instruction, idx);
           xRepliesApproved = false;
         }
       } else {
         await dispatchRewriteDraft(currentRepoForSubmit, token!, currentCommittedSha, scopedInstruction);
         const result = await pollRewriteDraftStatus(currentRepoForSubmit, token!, Date.now());
-        if (!result?.payload?.thread?.main) throw new Error('AI 수정 결과를 읽지 못했습니다.');
+        if (!result?.payload?.thread?.main) {
+          throw new Error('AI 수정 결과를 읽지 못했습니다. Actions 로그 접근 권한(actions:read)과 워크플로 상태를 확인해 주세요.');
+        }
         if (!result.payload.success) throw new Error(result.payload.error || 'AI 수정 실패');
         modelName = String(result.payload.meta?.model || '-');
 
@@ -1955,6 +2009,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     } catch (err: any) {
       if (statusEl) statusEl.textContent = '실패';
       showStatus(`AI 수정 실패: ${err.message}`, 'error');
+    } finally {
+      isAiRewriteInProgress = false;
     }
   }
 

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -215,7 +215,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     <!-- X Draft Review -->
     <div id="x-review-section" class="hidden mt-5 p-4 rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-anthro-darkSurface">
       <div class="flex items-center justify-between mb-3">
-        <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-200">X 게시 전 문안 검토</h3>
+        <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-200">X 게시 전 draft 검토</h3>
         <span id="x-review-meta" class="text-xs text-gray-400"></span>
       </div>
 
@@ -245,7 +245,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
           <div id="confirm-item-list" class="mb-4 max-h-40 overflow-y-auto text-xs text-gray-500 dark:text-gray-400 space-y-1"></div>
           <label class="mb-4 flex items-start gap-2 text-xs text-gray-600 dark:text-gray-300">
             <input type="checkbox" id="confirm-manual-approval" class="mt-0.5 accent-claude-500" checked />
-            <span>X 게시 전 문안 확인/수정 후 승인하기 (기본)</span>
+            <span>X 게시 전 draft 확인/수정 후 승인하기 (기본)</span>
           </label>
           <div class="flex gap-2">
             <button id="confirm-cancel" class="flex-1 px-4 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all">취소</button>
@@ -828,7 +828,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     const mainModel = draft.meta?.main_model || '-';
     const replyModel = draft.meta?.reply_model || '-';
     if (metaEl) metaEl.textContent = `main 모델: ${mainModel} · reply 모델: ${replyModel}`;
-    if (noteEl) noteEl.textContent = '문안을 직접 수정한 뒤 승인 게시할 수 있습니다.';
+    if (noteEl) noteEl.textContent = 'draft를 직접 수정한 뒤 승인 게시할 수 있습니다.';
 
     repliesEditor.innerHTML = (draft.thread.replies || []).map((reply, idx) => `
       <div>
@@ -1276,7 +1276,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
                 await dispatchApprovedPost(repo, token, commitSha, 'one_time_auto');
                 await pollApprovedPostStatus(repo, token, commitSha, Date.now());
               } else {
-                showStatus(`✅ 커밋 완료 · ${shortSha}\n📝 X 초안이 준비되었습니다. 문안을 확인한 뒤 승인해 주세요.`, 'success', { autoScroll: true });
+                showStatus(`✅ 커밋 완료 · ${shortSha}\n📝 X draft가 준비되었습니다. draft를 확인한 뒤 승인해 주세요.`, 'success', { autoScroll: true });
               }
             } else {
               showStatus(`✅ 커밋 완료 · ${shortSha}\n⚠️ X 초안을 찾지 못했습니다. Actions에서 notify-artifacts를 확인하세요.`, 'warn');
@@ -1382,7 +1382,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         if (liveProgress?.postingReply && liveProgress?.totalReplies) {
           showStatus(`✅ 커밋 완료 · ${shortSha}\n🐦 X reply ${liveProgress.postingReply}/${liveProgress.totalReplies} 게시 중...`, 'info');
         } else {
-          showStatus(`✅ 커밋 완료 · ${shortSha}\n🐦 승인된 문안으로 X 게시 중...`, 'info');
+          showStatus(`✅ 커밋 완료 · ${shortSha}\n🐦 승인된 draft로 X 게시 중...`, 'info');
         }
         setTimeout(tick, POLL_INTERVAL);
       };

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -254,7 +254,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       </div>
 
       <details class="mt-4 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid">
-        <summary class="text-sm font-semibold text-gray-700 dark:text-gray-200 cursor-pointer">AI로 텍스트 다듬기 (선택)</summary>
+        <summary class="text-sm font-semibold text-gray-700 dark:text-gray-200 cursor-pointer">AI로 텍스트 다듬기</summary>
         <div class="mt-3 space-y-3">
           <div class="p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-anthro-darkSurface">
             <label class="block text-xs text-gray-500 mb-1">Main instruction</label>
@@ -283,7 +283,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       </details>
 
       <div class="mt-4 flex flex-wrap gap-2">
-        <button id="x-approve-post-btn" class="px-4 py-2 rounded-lg bg-claude-500 text-white text-sm font-semibold hover:bg-claude-600 transition-all">전체 승인 후 X 게시</button>
+        <button id="x-approve-post-btn" class="px-4 py-2 rounded-lg bg-claude-500 text-white text-sm font-semibold hover:bg-claude-600 transition-all">X 게시</button>
+        <button id="x-approve-all-btn" class="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm font-semibold text-gray-700 dark:text-gray-200 hover:border-claude-400 transition-all">전체 승인</button>
         <button id="x-copy-thread-btn" class="px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-300 hover:border-claude-400 transition-all">스레드 복사</button>
       </div>
       <div id="x-review-note" class="mt-2 text-xs text-gray-400"></div>
@@ -976,6 +977,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   function updateReviewApprovalUi() {
     const mainBtn = document.getElementById('x-main-approve-btn');
     const repliesBtn = document.getElementById('x-replies-approve-btn');
+    const allBtn = document.getElementById('x-approve-all-btn') as HTMLButtonElement | null;
     const postBtn = document.getElementById('x-approve-post-btn') as HTMLButtonElement | null;
     const noteEl = document.getElementById('x-review-note');
 
@@ -987,6 +989,19 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       repliesBtn.textContent = xRepliesApproved ? 'replies 승인됨' : 'replies 승인';
       repliesBtn.className = `text-xs px-2 py-1 rounded-md border ${xRepliesApproved ? 'border-claude-300 text-claude-600 bg-claude-50 dark:bg-claude-950/20' : 'border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400'}`;
     }
+    if (allBtn) {
+      const allApproved = xMainApproved && xRepliesApproved;
+      allBtn.textContent = allApproved ? '전체 승인 해제' : '전체 승인';
+      allBtn.className = `px-4 py-2 rounded-lg border text-sm font-semibold transition-all ${
+        allApproved
+          ? 'border-claude-300 text-claude-700 bg-claude-50 dark:bg-claude-950/20'
+          : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-200 hover:border-claude-400'
+      }`;
+      allBtn.disabled = isPostingInProgress;
+      allBtn.classList.toggle('opacity-50', isPostingInProgress);
+      allBtn.classList.toggle('cursor-not-allowed', isPostingInProgress);
+    }
+
     if (postBtn) {
       const enabled = xMainApproved && xRepliesApproved;
       postBtn.disabled = !enabled || isPostingInProgress;
@@ -995,7 +1010,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       if (isPostingInProgress) {
         postBtn.textContent = '게시 진행 중...';
       } else {
-        postBtn.textContent = '전체 승인 후 X 게시';
+        postBtn.textContent = 'X 게시';
       }
     }
     if (noteEl) {
@@ -1914,6 +1929,14 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
   document.getElementById('x-replies-approve-btn')?.addEventListener('click', () => {
     xRepliesApproved = !xRepliesApproved;
+    updateReviewApprovalUi();
+  });
+
+  document.getElementById('x-approve-all-btn')?.addEventListener('click', () => {
+    if (isPostingInProgress) return;
+    const allApproved = xMainApproved && xRepliesApproved;
+    xMainApproved = !allApproved;
+    xRepliesApproved = !allApproved;
     updateReviewApprovalUi();
   });
 

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -1446,14 +1446,14 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     const thread = collectEditedThread();
     if (!thread) {
       showStatus('X draft를 불러오지 못했습니다.', 'error');
-      return;
+      return false;
     }
 
     const failures = validateThreadLimit(thread.main, thread.replies);
     if (failures.length > 0) {
       const msg = failures.map((f) => `${f.phase} ${f.used}/${X_HARD_LIMIT}`).join(', ');
       showStatus(`길이 제한 초과: ${msg}`, 'error', { autoScroll: true });
-      return;
+      return false;
     }
 
     const body = {
@@ -1481,6 +1481,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       if (dispatchRes.status === 403) throw new Error('workflow 실행 권한이 부족합니다. 토큰 scope를 확인해 주세요 (repo/workflow).');
       throw new Error(`승인 게시 워크플로우 실행 실패 (${dispatchRes.status}): ${err}`);
     }
+    return true;
   }
 
   async function dispatchRewriteDraft(repo: string, token: string, commitSha: string, instruction: string) {
@@ -1522,7 +1523,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       });
       if (!res.ok) return null;
       const data = await res.json();
-      return (data.workflow_runs || []).find((r: any) => Date.parse(r.created_at || '') >= (dispatchedAt - 30000));
+      return (data.workflow_runs || []).find((r: any) => Date.parse(r.created_at || '') >= dispatchedAt);
     };
 
     const findJob = async (runId: number) => {
@@ -1636,7 +1637,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
               if (trackingState.requireManualApproval === false) {
                 showStatus(`✅ 커밋 완료 · ${shortSha}\n🤖 자동 승인 모드로 X 게시를 시작합니다...`, 'info', { autoScroll: true });
-                await dispatchApprovedPost(repo, token, commitSha, 'one_time_auto');
+                const dispatched = await dispatchApprovedPost(repo, token, commitSha, 'one_time_auto');
+                if (!dispatched) return;
                 await pollApprovedPostStatus(repo, token, commitSha, Date.now());
               } else {
                 showStatus(`✅ 커밋 완료 · ${shortSha}\n📝 X draft가 준비되었습니다. draft를 확인한 뒤 승인해 주세요.`, 'success', { autoScroll: true });
@@ -1911,7 +1913,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         await runMockPostFlow(currentCommittedSha);
       } else {
         showStatus(`✅ 커밋 완료 · ${currentCommittedSha.slice(0, 7)}\n⏳ 승인 게시 워크플로 실행 중...`, 'info');
-        await dispatchApprovedPost(currentRepoForSubmit, token!, currentCommittedSha, 'manual_approved');
+        const dispatched = await dispatchApprovedPost(currentRepoForSubmit, token!, currentCommittedSha, 'manual_approved');
+        if (!dispatched) return;
         await pollApprovedPostStatus(currentRepoForSubmit, token!, currentCommittedSha, Date.now());
       }
     } catch (err: any) {

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -221,15 +221,49 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
       <div class="space-y-3">
         <div>
-          <label class="block text-xs text-gray-500 mb-1">Main post</label>
+          <div class="flex items-center justify-between mb-1">
+            <label class="block text-xs text-gray-500">Main post</label>
+            <button id="x-main-approve-btn" class="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400">main 승인</button>
+          </div>
           <textarea id="x-main-input" rows="4" class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"></textarea>
           <div id="x-main-count" class="mt-1 text-xs text-gray-400 font-mono">0/280</div>
         </div>
-        <div id="x-replies-editor" class="space-y-2"></div>
+        <div>
+          <div class="flex items-center justify-between mb-1">
+            <label class="block text-xs text-gray-500">Replies</label>
+            <button id="x-replies-approve-btn" class="text-xs px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400">replies 승인</button>
+          </div>
+          <div id="x-replies-editor" class="space-y-2"></div>
+        </div>
+      </div>
+
+      <div class="mt-4 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid">
+        <label class="block text-xs text-gray-500 mb-2">AI 피드백 반영</label>
+        <div class="space-y-3">
+          <div>
+            <label class="block text-xs text-gray-500 mb-1">Main instruction</label>
+            <textarea id="x-ai-main-instruction" rows="2" placeholder="예: main을 더 간결하고 임팩트 있게 정리해줘."
+              class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-anthro-darkSurface text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"></textarea>
+            <button id="x-ai-main-rewrite-btn" class="mt-1 px-3 py-1.5 rounded-md border border-gray-200 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-300 hover:border-claude-400 transition-all">main만 AI 수정</button>
+          </div>
+          <div>
+            <div class="flex items-center gap-2 mb-1">
+              <label class="text-xs text-gray-500">Reply target</label>
+              <select id="x-ai-reply-target" class="px-2 py-1 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-anthro-darkSurface text-xs">
+                <option value="all">전체 replies</option>
+              </select>
+            </div>
+            <textarea id="x-ai-reply-instruction" rows="2" placeholder="예: reply 2는 실무 적용 관점으로 다시 써줘."
+              class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-anthro-darkSurface text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500"></textarea>
+            <button id="x-ai-reply-rewrite-btn" class="mt-1 px-3 py-1.5 rounded-md border border-gray-200 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-300 hover:border-claude-400 transition-all">reply AI 수정</button>
+          </div>
+        </div>
+        <div class="mt-2 text-xs text-gray-400" id="x-ai-status"></div>
+        <div id="x-ai-history" class="mt-2 space-y-1 text-xs text-gray-500 dark:text-gray-400"></div>
       </div>
 
       <div class="mt-4 flex flex-wrap gap-2">
-        <button id="x-approve-post-btn" class="px-4 py-2 rounded-lg bg-claude-500 text-white text-sm font-semibold hover:bg-claude-600 transition-all">승인하고 X 게시</button>
+        <button id="x-approve-post-btn" class="px-4 py-2 rounded-lg bg-claude-500 text-white text-sm font-semibold hover:bg-claude-600 transition-all">전체 승인 후 X 게시</button>
         <button id="x-copy-thread-btn" class="px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-300 hover:border-claude-400 transition-all">스레드 복사</button>
       </div>
       <div id="x-review-note" class="mt-2 text-xs text-gray-400"></div>
@@ -273,6 +307,9 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     thread: { main: string; replies: string[] };
     meta?: Record<string, any>;
   } | null = null;
+  let xMainApproved = false;
+  let xRepliesApproved = false;
+  let xAiHistory: Array<{ at: string; target: string; instruction: string; model: string; summary: string }> = [];
 
   const WORKFLOW_TRACKING_KEY = 'nlp_paper_news_admin_workflow_tracking_v1';
   const X_HARD_LIMIT = 280;
@@ -793,6 +830,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         const used = countXChars(mainInput.value);
         mainCount.textContent = `${used}/${X_HARD_LIMIT}`;
         mainCount.className = `mt-1 text-xs font-mono ${used > X_HARD_LIMIT ? 'text-red-500' : 'text-gray-400'}`;
+        xMainApproved = false;
+        updateReviewApprovalUi();
       };
       mainInput.addEventListener('input', updateMain);
       updateMain();
@@ -807,19 +846,69 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
           countEl.textContent = `${used}/${X_HARD_LIMIT}`;
           countEl.className = `text-xs font-mono ${used > X_HARD_LIMIT ? 'text-red-500' : 'text-gray-400'}`;
         }
+        xRepliesApproved = false;
+        updateReviewApprovalUi();
       };
       el.addEventListener('input', update);
       update();
     });
   }
 
-  function showXDraftReview(draft: { commitSha: string; thread: { main: string; replies: string[] }; meta?: Record<string, any> }) {
+  function updateReviewApprovalUi() {
+    const mainBtn = document.getElementById('x-main-approve-btn');
+    const repliesBtn = document.getElementById('x-replies-approve-btn');
+    const postBtn = document.getElementById('x-approve-post-btn') as HTMLButtonElement | null;
+    const noteEl = document.getElementById('x-review-note');
+
+    if (mainBtn) {
+      mainBtn.textContent = xMainApproved ? 'main 승인됨' : 'main 승인';
+      mainBtn.className = `text-xs px-2 py-1 rounded-md border ${xMainApproved ? 'border-emerald-300 text-emerald-600' : 'border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400'}`;
+    }
+    if (repliesBtn) {
+      repliesBtn.textContent = xRepliesApproved ? 'replies 승인됨' : 'replies 승인';
+      repliesBtn.className = `text-xs px-2 py-1 rounded-md border ${xRepliesApproved ? 'border-emerald-300 text-emerald-600' : 'border-gray-200 dark:border-gray-700 text-gray-500 hover:border-claude-400'}`;
+    }
+    if (postBtn) {
+      const enabled = xMainApproved && xRepliesApproved;
+      postBtn.disabled = !enabled;
+      postBtn.classList.toggle('opacity-50', !enabled);
+      postBtn.classList.toggle('cursor-not-allowed', !enabled);
+    }
+    if (noteEl) {
+      noteEl.textContent = (xMainApproved && xRepliesApproved)
+        ? 'main/replies 승인 완료. 이제 게시할 수 있습니다.'
+        : '게시 전 main과 replies를 각각 승인해 주세요.';
+    }
+  }
+
+  function renderAiHistory() {
+    const el = document.getElementById('x-ai-history');
+    if (!el) return;
+    if (xAiHistory.length === 0) {
+      el.innerHTML = '<div class="text-gray-400">AI 수정 기록이 아직 없습니다.</div>';
+      return;
+    }
+    el.innerHTML = xAiHistory.slice().reverse().map((h) => `
+      <div class="rounded-md border border-gray-200 dark:border-gray-700 px-2 py-1">
+        <div class="text-[11px] text-gray-400">${escapeHtml(h.at)} · model ${escapeHtml(h.model)}</div>
+        <div>target: ${escapeHtml(h.target)}</div>
+        <div>instruction: ${escapeHtml(h.instruction)}</div>
+        <div class="text-gray-400">result: ${escapeHtml(h.summary)}</div>
+      </div>
+    `).join('');
+  }
+
+  function showXDraftReview(
+    draft: { commitSha: string; thread: { main: string; replies: string[] }; meta?: Record<string, any> },
+    opts: { preserveHistory?: boolean } = { preserveHistory: false }
+  ) {
     xDraftData = draft;
     const section = document.getElementById('x-review-section');
     const mainInput = document.getElementById('x-main-input') as HTMLTextAreaElement | null;
     const repliesEditor = document.getElementById('x-replies-editor');
     const metaEl = document.getElementById('x-review-meta');
     const noteEl = document.getElementById('x-review-note');
+    const replyTarget = document.getElementById('x-ai-reply-target') as HTMLSelectElement | null;
 
     if (!section || !mainInput || !repliesEditor) return;
     section.classList.remove('hidden');
@@ -828,7 +917,11 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     const mainModel = draft.meta?.main_model || '-';
     const replyModel = draft.meta?.reply_model || '-';
     if (metaEl) metaEl.textContent = `main 모델: ${mainModel} · reply 모델: ${replyModel}`;
-    if (noteEl) noteEl.textContent = 'draft를 직접 수정한 뒤 승인 게시할 수 있습니다.';
+    if (!opts.preserveHistory) xAiHistory = [];
+    renderAiHistory();
+    xMainApproved = false;
+    xRepliesApproved = false;
+    if (noteEl) noteEl.textContent = '텍스트를 확인/수정하고 승인해 주세요.';
 
     repliesEditor.innerHTML = (draft.thread.replies || []).map((reply, idx) => `
       <div>
@@ -842,7 +935,15 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       </div>
     `).join('');
 
+    if (replyTarget) {
+      replyTarget.innerHTML = [
+        '<option value="all">전체 replies</option>',
+        ...(draft.thread.replies || []).map((_: string, idx: number) => `<option value="${idx + 1}">reply ${idx + 1}</option>`)
+      ].join('');
+    }
+
     bindXCountIndicators();
+    updateReviewApprovalUi();
   }
 
   // Clear preview
@@ -1148,6 +1249,22 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     }
   }
 
+  async function fetchLogPayloadByKey(repo: string, token: string, jobId: number, key: string) {
+    const res = await fetch(`https://api.github.com/repos/${repo}/actions/jobs/${jobId}/logs`, {
+      headers: { 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json' }
+    });
+    if (!res.ok) return null;
+    const text = await res.text();
+    const regex = new RegExp(`${key}=([A-Za-z0-9+/=]+)`);
+    const match = text.match(regex);
+    if (!match?.[1]) return null;
+    try {
+      return JSON.parse(base64ToUtf8(match[1]));
+    } catch {
+      return null;
+    }
+  }
+
   async function dispatchApprovedPost(repo: string, token: string, commitSha: string, approvalMode: 'manual_approved' | 'one_time_auto') {
     const thread = collectEditedThread();
     if (!thread) {
@@ -1185,6 +1302,71 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       const err = await dispatchRes.text();
       throw new Error(`승인 게시 워크플로우 실행 실패 (${dispatchRes.status}): ${err}`);
     }
+  }
+
+  async function dispatchRewriteDraft(repo: string, token: string, commitSha: string, instruction: string) {
+    const thread = collectEditedThread();
+    if (!thread) throw new Error('현재 편집 중인 thread를 읽지 못했습니다.');
+
+    const dispatchRes = await fetch(`https://api.github.com/repos/${repo}/actions/workflows/rewrite-x-draft.yml/dispatches`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `token ${token}`,
+        'Accept': 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ref: 'main',
+        inputs: {
+          commit_sha: commitSha,
+          instruction,
+          current_thread_json_b64: utf8ToBase64(JSON.stringify(thread)),
+        }
+      }),
+    });
+    if (!dispatchRes.ok) {
+      const err = await dispatchRes.text();
+      throw new Error(`AI 수정 워크플로우 실행 실패 (${dispatchRes.status}): ${err}`);
+    }
+  }
+
+  async function pollRewriteDraftStatus(repo: string, token: string, dispatchedAt: number) {
+    const POLL_INTERVAL = 5000;
+    const MAX_POLLS = 72;
+    let polls = 0;
+
+    const findRun = async () => {
+      const res = await fetch(`https://api.github.com/repos/${repo}/actions/workflows/rewrite-x-draft.yml/runs?per_page=10`, {
+        headers: { 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json' }
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return (data.workflow_runs || []).find((r: any) => Date.parse(r.created_at || '') >= (dispatchedAt - 30000));
+    };
+
+    const findJob = async (runId: number) => {
+      const res = await fetch(`https://api.github.com/repos/${repo}/actions/runs/${runId}/jobs`, {
+        headers: { 'Authorization': `token ${token}`, 'Accept': 'application/vnd.github.v3+json' }
+      });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return (data.jobs || []).find((j: any) => j.name === 'rewrite');
+    };
+
+    return new Promise<any>((resolve) => {
+      const tick = async () => {
+        polls++;
+        if (polls > MAX_POLLS) return resolve(null);
+        const run = await findRun();
+        if (!run) return setTimeout(tick, POLL_INTERVAL);
+        if (run.status !== 'completed') return setTimeout(tick, POLL_INTERVAL);
+        const job = await findJob(run.id);
+        if (!job?.id) return resolve(null);
+        const payload = await fetchLogPayloadByKey(repo, token, job.id, 'REWRITE_RESULT_BASE64');
+        resolve({ run, payload });
+      };
+      tick();
+    });
   }
 
   async function pollWorkflowStatus(repo: string, token: string, commitSha: string, state?: WorkflowTrackingState) {
@@ -1368,12 +1550,27 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         }
 
         if (run.status === 'completed') {
+          const postResult = postJob?.id
+            ? await fetchLogPayloadByKey(repo, token, postJob.id, 'POST_RESULT_BASE64')
+            : null;
+
           if (run.conclusion === 'success') {
-            showStatus(`✅ 커밋 완료 · ${shortSha}\n✅ X 포스팅 성공!`, 'success', { autoScroll: true });
-            fadeStatusAfter(7000);
+            if (postResult?.degradedMode === 'main_only') {
+              showStatus(`✅ 커밋 완료 · ${shortSha}\n⚠️ main만 게시되었습니다. 남은 replies는 수동으로 이어서 게시해 주세요.`, 'warn', { autoScroll: true });
+            } else {
+              showStatus(`✅ 커밋 완료 · ${shortSha}\n✅ X 포스팅 성공!`, 'success', { autoScroll: true });
+              fadeStatusAfter(7000);
+            }
           } else {
-            const degraded = liveProgress?.degraded ? '\n⚠️ reply 차단(main-only) 가능성: Actions 로그를 확인하세요.' : '';
-            showStatus(`✅ 커밋 완료 · ${shortSha}\n❌ X 포스팅 실패${degraded}`, 'error', { autoScroll: true });
+            let guide = 'Actions 로그를 확인해 주세요.';
+            if (postResult?.errorCode === 'local_length_guard' || postResult?.failurePhase === 'validation') {
+              guide = '길이 제한 초과입니다. main/replies 텍스트를 줄인 뒤 다시 승인해 주세요.';
+            } else if ([403, 429].includes(Number(postResult?.httpStatus))) {
+              guide = '정책/레이트 제한 가능성이 높습니다. 같은 텍스트 재시도 대신 수정 후 재게시를 권장합니다.';
+            } else if (postResult?.errorCode === 'network_error') {
+              guide = '네트워크 오류입니다. 잠시 후 다시 시도해 주세요.';
+            }
+            showStatus(`✅ 커밋 완료 · ${shortSha}\n❌ X 포스팅 실패\n${guide}`, 'error', { autoScroll: true });
           }
           resolve();
           return;
@@ -1495,6 +1692,10 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       showStatus('승인할 X 초안이 없습니다. 먼저 항목을 커밋해 주세요.', 'warn');
       return;
     }
+    if (!(xMainApproved && xRepliesApproved)) {
+      showStatus('게시 전 main과 replies를 각각 승인해 주세요.', 'warn');
+      return;
+    }
 
     try {
       showStatus(`✅ 커밋 완료 · ${currentCommittedSha.slice(0, 7)}\n⏳ 승인 게시 워크플로 실행 중...`, 'info');
@@ -1503,6 +1704,104 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     } catch (err: any) {
       showStatus(`승인 게시 실행 실패: ${err.message}`, 'error');
     }
+  });
+
+  document.getElementById('x-main-approve-btn')?.addEventListener('click', () => {
+    xMainApproved = !xMainApproved;
+    updateReviewApprovalUi();
+  });
+
+  document.getElementById('x-replies-approve-btn')?.addEventListener('click', () => {
+    xRepliesApproved = !xRepliesApproved;
+    updateReviewApprovalUi();
+  });
+
+  async function runAiRewrite(target: 'main' | 'replies', instruction: string, replyTarget: 'all' | number = 'all') {
+    const token = localStorage.getItem('github_token');
+    const statusEl = document.getElementById('x-ai-status');
+    if (!token || !currentRepoForSubmit || !currentCommittedSha) {
+      showStatus('AI 수정을 실행하려면 먼저 커밋 후 X draft를 불러와야 합니다.', 'warn');
+      return;
+    }
+    if (!instruction.trim()) {
+      showToast('instruction을 입력해 주세요.');
+      return;
+    }
+
+    const scopedInstruction = target === 'main'
+      ? `[target: main only]\n${instruction}`
+      : replyTarget === 'all'
+      ? `[target: all replies]\n${instruction}`
+      : `[target: reply ${replyTarget} only; keep others]\n${instruction}`;
+
+    try {
+      if (statusEl) statusEl.textContent = `${target === 'main' ? 'main' : 'reply'} AI 수정 요청 중...`;
+      await dispatchRewriteDraft(currentRepoForSubmit, token, currentCommittedSha, scopedInstruction);
+      const result = await pollRewriteDraftStatus(currentRepoForSubmit, token, Date.now());
+
+      if (!result?.payload?.thread?.main) throw new Error('AI 수정 결과를 읽지 못했습니다.');
+      if (!result.payload.success) throw new Error(result.payload.error || 'AI 수정 실패');
+
+      const current = collectEditedThread();
+      if (!current) throw new Error('현재 thread를 읽지 못했습니다.');
+
+      const nextThread = {
+        main: current.main,
+        replies: [...current.replies],
+      };
+
+      if (target === 'main') {
+        nextThread.main = String(result.payload.thread.main || nextThread.main);
+        xMainApproved = false;
+      } else if (replyTarget === 'all') {
+        nextThread.replies = Array.isArray(result.payload.thread.replies)
+          ? result.payload.thread.replies.map((x: any) => String(x || ''))
+          : nextThread.replies;
+        xRepliesApproved = false;
+      } else {
+        const idx = replyTarget - 1;
+        const rewrittenReply = Array.isArray(result.payload.thread.replies) ? result.payload.thread.replies[idx] : null;
+        if (typeof rewrittenReply === 'string') nextThread.replies[idx] = rewrittenReply;
+        xRepliesApproved = false;
+      }
+
+      showXDraftReview({
+        commitSha: currentCommittedSha,
+        thread: nextThread,
+        meta: result.payload.meta || {},
+      }, { preserveHistory: true });
+
+      xAiHistory.push({
+        at: new Date().toLocaleString('ko-KR'),
+        target: target === 'main' ? 'main' : (replyTarget === 'all' ? 'all replies' : `reply ${replyTarget}`),
+        instruction,
+        model: String(result.payload.meta?.model || '-'),
+        summary: `main ${countXChars(nextThread.main)}자 · replies ${nextThread.replies.length}건`,
+      });
+      renderAiHistory();
+      if (statusEl) statusEl.textContent = '완료';
+      showToast('AI 수정 결과를 반영했습니다.');
+    } catch (err: any) {
+      if (statusEl) statusEl.textContent = '실패';
+      showStatus(`AI 수정 실패: ${err.message}`, 'error');
+    }
+  }
+
+  document.getElementById('x-ai-main-rewrite-btn')?.addEventListener('click', async () => {
+    const input = document.getElementById('x-ai-main-instruction') as HTMLTextAreaElement | null;
+    const instruction = input?.value.trim() || '';
+    await runAiRewrite('main', instruction, 'all');
+    if (input) input.value = '';
+  });
+
+  document.getElementById('x-ai-reply-rewrite-btn')?.addEventListener('click', async () => {
+    const input = document.getElementById('x-ai-reply-instruction') as HTMLTextAreaElement | null;
+    const targetEl = document.getElementById('x-ai-reply-target') as HTMLSelectElement | null;
+    const instruction = input?.value.trim() || '';
+    const selected = targetEl?.value || 'all';
+    const replyTarget: 'all' | number = selected === 'all' ? 'all' : Number(selected);
+    await runAiRewrite('replies', instruction, replyTarget);
+    if (input) input.value = '';
   });
 
   document.getElementById('x-copy-thread-btn')?.addEventListener('click', async () => {

--- a/web/src/pages/admin.astro
+++ b/web/src/pages/admin.astro
@@ -50,6 +50,10 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         <input type="text" id="github-repo" value="chanmuzi/NLP-Paper-News"
           class="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-anthro-darkMid text-sm text-gray-900 dark:text-gray-100 outline-none focus:border-claude-500 transition-all font-mono" />
       </div>
+      <label class="mt-3 flex items-start gap-2 text-xs text-gray-600 dark:text-gray-300">
+        <input type="checkbox" id="mock-mode-toggle" class="mt-0.5 accent-claude-500" />
+        <span>로컬 mock 모드 (GitHub 없이 UI 흐름 테스트)</span>
+      </label>
     </div>
 
     <!-- Date (shared) -->
@@ -312,8 +316,19 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   let xAiHistory: Array<{ at: string; target: string; instruction: string; model: string; summary: string }> = [];
 
   const WORKFLOW_TRACKING_KEY = 'nlp_paper_news_admin_workflow_tracking_v1';
+  const MOCK_MODE_KEY = 'nlp_paper_news_admin_mock_mode_v1';
   const X_HARD_LIMIT = 280;
   const URL_REGEX = /https?:\/\/[^\s)]+/gi;
+
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  function isMockMode() {
+    return localStorage.getItem(MOCK_MODE_KEY) === 'true';
+  }
+
+  function setMockMode(enabled: boolean) {
+    localStorage.setItem(MOCK_MODE_KEY, enabled ? 'true' : 'false');
+  }
 
   function utf8ToBase64(str: string) {
     return btoa(unescape(encodeURIComponent(str)));
@@ -812,6 +827,43 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     return failures;
   }
 
+  function clipToXLimit(text: string, limit = X_HARD_LIMIT) {
+    const src = String(text || '');
+    if (countXChars(src) <= limit) return src;
+    const chars = Array.from(src);
+    while (chars.length > 0) {
+      const candidate = chars.join('');
+      if (countXChars(candidate) <= limit) return candidate;
+      chars.pop();
+    }
+    return '';
+  }
+
+  function buildMockDraft(items: any[], commitSha: string) {
+    const titles = items.slice(0, 3).map((i) => i.title).join(' · ');
+    const mainBase = `📌 이번 업데이트 ${items.length}건\n${titles}${items.length > 3 ? ` 외 ${items.length - 3}건` : ''}`;
+    const replies = items.map((item, idx) => {
+      const lines = [
+        `${idx + 1}) ${item.title}`,
+        `- ${item.org}`,
+      ];
+      if (item.url) lines.push(item.url);
+      return clipToXLimit(lines.join('\n'));
+    });
+
+    return {
+      commitSha,
+      thread: {
+        main: clipToXLimit(mainBase),
+        replies,
+      },
+      meta: {
+        main_model: 'mock-local',
+        reply_model: 'mock-local',
+      }
+    };
+  }
+
   function collectEditedThread() {
     const mainInput = document.getElementById('x-main-input') as HTMLTextAreaElement | null;
     if (!mainInput) return null;
@@ -957,9 +1009,47 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   async function submitToGitHub(items: any[]) {
     const token = localStorage.getItem('github_token');
     const repo = (document.getElementById('github-repo') as HTMLInputElement)?.value || 'chanmuzi/NLP-Paper-News';
+    const mockMode = isMockMode();
 
-    if (!token) {
+    if (!token && !mockMode) {
       showStatus('GitHub 토큰이 설정되지 않았습니다. 상단 GitHub 버튼에서 토큰을 입력하세요.', 'error');
+      return;
+    }
+
+    if (mockMode) {
+      setSubmitLoading(true);
+      showStatus('1/3 [mock] 입력 항목 검증 중...', 'info');
+      await sleep(250);
+
+      const newItems = items.filter(i => !submittedIds.has(i.id) && !existingIds.has(i.id));
+      const skippedCount = items.length - newItems.length;
+      if (newItems.length === 0) {
+        showStatus(`[mock] 추가할 새 항목이 없습니다. ${skippedCount}개 항목이 이미 존재합니다.`, 'warn');
+        setSubmitLoading(false);
+        return;
+      }
+
+      showStatus('2/3 [mock] 커밋 시뮬레이션 중...', 'info');
+      await sleep(350);
+
+      const fakeSha = Math.random().toString(16).slice(2, 9).padEnd(7, '0');
+      items.forEach(i => { submittedIds.add(i.id); existingIds.add(i.id); });
+      parsedItems = [];
+      renderPreview();
+      clearInputFields();
+      setSubmitLoading(false);
+
+      currentCommittedSha = fakeSha;
+      currentRepoForSubmit = repo;
+      const draft = buildMockDraft(newItems, fakeSha);
+      showXDraftReview(draft);
+
+      if (requireManualApprovalForCurrentSubmit === false) {
+        showStatus(`✅ [mock] 커밋 완료 · ${fakeSha}\n🤖 자동 승인 모드로 X 게시를 시작합니다...`, 'info', { autoScroll: true });
+        await runMockPostFlow(fakeSha);
+      } else {
+        showStatus(`✅ [mock] 커밋 완료 · ${fakeSha}\n📝 X draft가 준비되었습니다. draft를 확인한 뒤 승인해 주세요.`, 'success', { autoScroll: true });
+      }
       return;
     }
 
@@ -1587,6 +1677,30 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     });
   }
 
+  async function runMockPostFlow(commitSha: string) {
+    const shortSha = commitSha.slice(0, 7);
+    const thread = collectEditedThread();
+    if (!thread) {
+      showStatus(`[mock] 게시할 draft를 읽지 못했습니다.`, 'error');
+      return;
+    }
+    const failures = validateThreadLimit(thread.main, thread.replies);
+    if (failures.length > 0) {
+      const msg = failures.map((f) => `${f.phase} ${f.used}/${X_HARD_LIMIT}`).join(', ');
+      showStatus(`✅ [mock] 커밋 완료 · ${shortSha}\n❌ 길이 제한 초과: ${msg}`, 'error', { autoScroll: true });
+      return;
+    }
+
+    showStatus(`✅ [mock] 커밋 완료 · ${shortSha}\n🐦 X 게시 시뮬레이션 시작...`, 'info');
+    await sleep(400);
+    for (let i = 0; i < thread.replies.length; i++) {
+      showStatus(`✅ [mock] 커밋 완료 · ${shortSha}\n🐦 X reply ${i + 1}/${thread.replies.length} 게시 중...`, 'info');
+      await sleep(250);
+    }
+    showStatus(`✅ [mock] 커밋 완료 · ${shortSha}\n✅ X 포스팅 성공!`, 'success', { autoScroll: true });
+    fadeStatusAfter(5000);
+  }
+
   function fadeStatusAfter(ms: number) {
     setTimeout(() => {
       const statusEl = document.getElementById('submit-status');
@@ -1651,7 +1765,7 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       return;
     }
     const token = localStorage.getItem('github_token');
-    if (!token) {
+    if (!token && !isMockMode()) {
       showStatus('GitHub 토큰이 설정되지 않았습니다. 상단 GitHub 버튼에서 토큰을 입력하세요.', 'error');
       return;
     }
@@ -1684,7 +1798,8 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
   document.getElementById('x-approve-post-btn')?.addEventListener('click', async () => {
     const token = localStorage.getItem('github_token');
-    if (!token) {
+    const mockMode = isMockMode();
+    if (!token && !mockMode) {
       showStatus('GitHub 토큰이 필요합니다.', 'error');
       return;
     }
@@ -1698,9 +1813,13 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     }
 
     try {
-      showStatus(`✅ 커밋 완료 · ${currentCommittedSha.slice(0, 7)}\n⏳ 승인 게시 워크플로 실행 중...`, 'info');
-      await dispatchApprovedPost(currentRepoForSubmit, token, currentCommittedSha, 'manual_approved');
-      await pollApprovedPostStatus(currentRepoForSubmit, token, currentCommittedSha, Date.now());
+      if (mockMode) {
+        await runMockPostFlow(currentCommittedSha);
+      } else {
+        showStatus(`✅ 커밋 완료 · ${currentCommittedSha.slice(0, 7)}\n⏳ 승인 게시 워크플로 실행 중...`, 'info');
+        await dispatchApprovedPost(currentRepoForSubmit, token!, currentCommittedSha, 'manual_approved');
+        await pollApprovedPostStatus(currentRepoForSubmit, token!, currentCommittedSha, Date.now());
+      }
     } catch (err: any) {
       showStatus(`승인 게시 실행 실패: ${err.message}`, 'error');
     }
@@ -1718,8 +1837,9 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
   async function runAiRewrite(target: 'main' | 'replies', instruction: string, replyTarget: 'all' | number = 'all') {
     const token = localStorage.getItem('github_token');
+    const mockMode = isMockMode();
     const statusEl = document.getElementById('x-ai-status');
-    if (!token || !currentRepoForSubmit || !currentCommittedSha) {
+    if ((!token && !mockMode) || !currentRepoForSubmit || !currentCommittedSha) {
       showStatus('AI 수정을 실행하려면 먼저 커밋 후 X draft를 불러와야 합니다.', 'warn');
       return;
     }
@@ -1735,13 +1855,6 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
       : `[target: reply ${replyTarget} only; keep others]\n${instruction}`;
 
     try {
-      if (statusEl) statusEl.textContent = `${target === 'main' ? 'main' : 'reply'} AI 수정 요청 중...`;
-      await dispatchRewriteDraft(currentRepoForSubmit, token, currentCommittedSha, scopedInstruction);
-      const result = await pollRewriteDraftStatus(currentRepoForSubmit, token, Date.now());
-
-      if (!result?.payload?.thread?.main) throw new Error('AI 수정 결과를 읽지 못했습니다.');
-      if (!result.payload.success) throw new Error(result.payload.error || 'AI 수정 실패');
-
       const current = collectEditedThread();
       if (!current) throw new Error('현재 thread를 읽지 못했습니다.');
 
@@ -1749,33 +1862,60 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
         main: current.main,
         replies: [...current.replies],
       };
+      let modelName = 'mock-local';
+      if (statusEl) statusEl.textContent = `${target === 'main' ? 'main' : 'reply'} AI 수정 요청 중...`;
 
-      if (target === 'main') {
-        nextThread.main = String(result.payload.thread.main || nextThread.main);
-        xMainApproved = false;
-      } else if (replyTarget === 'all') {
-        nextThread.replies = Array.isArray(result.payload.thread.replies)
-          ? result.payload.thread.replies.map((x: any) => String(x || ''))
-          : nextThread.replies;
-        xRepliesApproved = false;
+      if (mockMode) {
+        const append = (base: string) => clipToXLimit(`${base}\n\n[AI edit] ${instruction}`);
+        if (target === 'main') {
+          nextThread.main = append(nextThread.main);
+          xMainApproved = false;
+        } else if (replyTarget === 'all') {
+          nextThread.replies = nextThread.replies.map((r) => append(r));
+          xRepliesApproved = false;
+        } else {
+          const idx = replyTarget - 1;
+          if (nextThread.replies[idx]) nextThread.replies[idx] = append(nextThread.replies[idx]);
+          xRepliesApproved = false;
+        }
       } else {
-        const idx = replyTarget - 1;
-        const rewrittenReply = Array.isArray(result.payload.thread.replies) ? result.payload.thread.replies[idx] : null;
-        if (typeof rewrittenReply === 'string') nextThread.replies[idx] = rewrittenReply;
-        xRepliesApproved = false;
+        await dispatchRewriteDraft(currentRepoForSubmit, token!, currentCommittedSha, scopedInstruction);
+        const result = await pollRewriteDraftStatus(currentRepoForSubmit, token!, Date.now());
+        if (!result?.payload?.thread?.main) throw new Error('AI 수정 결과를 읽지 못했습니다.');
+        if (!result.payload.success) throw new Error(result.payload.error || 'AI 수정 실패');
+        modelName = String(result.payload.meta?.model || '-');
+
+        if (target === 'main') {
+          nextThread.main = String(result.payload.thread.main || nextThread.main);
+          xMainApproved = false;
+        } else if (replyTarget === 'all') {
+          nextThread.replies = Array.isArray(result.payload.thread.replies)
+            ? result.payload.thread.replies.map((x: any) => String(x || ''))
+            : nextThread.replies;
+          xRepliesApproved = false;
+        } else {
+          const idx = replyTarget - 1;
+          const rewrittenReply = Array.isArray(result.payload.thread.replies) ? result.payload.thread.replies[idx] : null;
+          if (typeof rewrittenReply === 'string') nextThread.replies[idx] = rewrittenReply;
+          xRepliesApproved = false;
+        }
       }
 
       showXDraftReview({
         commitSha: currentCommittedSha,
         thread: nextThread,
-        meta: result.payload.meta || {},
+        meta: {
+          ...(xDraftData?.meta || {}),
+          main_model: target === 'main' ? modelName : (xDraftData?.meta?.main_model || '-'),
+          reply_model: target === 'replies' ? modelName : (xDraftData?.meta?.reply_model || '-'),
+        },
       }, { preserveHistory: true });
 
       xAiHistory.push({
         at: new Date().toLocaleString('ko-KR'),
         target: target === 'main' ? 'main' : (replyTarget === 'all' ? 'all replies' : `reply ${replyTarget}`),
         instruction,
-        model: String(result.payload.meta?.model || '-'),
+        model: modelName,
         summary: `main ${countXChars(nextThread.main)}자 · replies ${nextThread.replies.length}건`,
       });
       renderAiHistory();
@@ -1820,8 +1960,12 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
   function updateTokenStatus() {
     const statusEl = document.getElementById('token-status');
     const token = localStorage.getItem('github_token');
+    const mockMode = isMockMode();
     if (statusEl) {
-      if (token) {
+      if (mockMode) {
+        statusEl.textContent = 'MOCK';
+        statusEl.className = 'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-400';
+      } else if (token) {
         statusEl.textContent = '연결됨';
         statusEl.className = 'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400';
       } else {
@@ -1849,6 +1993,13 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
     localStorage.removeItem('github_token');
     updateTokenStatus();
     showToast('토큰이 삭제되었습니다');
+  });
+
+  document.getElementById('mock-mode-toggle')?.addEventListener('change', (e) => {
+    const enabled = (e.target as HTMLInputElement).checked;
+    setMockMode(enabled);
+    updateTokenStatus();
+    showToast(enabled ? '로컬 mock 모드가 켜졌습니다' : '로컬 mock 모드가 꺼졌습니다');
   });
 
   function showToast(message: string) {
@@ -1890,6 +2041,10 @@ const currentWeek = Math.ceil((now.getDate() + firstDay) / 7).toString();
 
   // ─── Init ──────────────────────────────
   updateTokenStatus();
+  const mockModeToggle = document.getElementById('mock-mode-toggle') as HTMLInputElement | null;
+  if (mockModeToggle) {
+    mockModeToggle.checked = isMockMode();
+  }
   const savedRepo = localStorage.getItem('github_repo');
   if (savedRepo) {
     (document.getElementById('github-repo') as HTMLInputElement).value = savedRepo;


### PR DESCRIPTION
## 변경 요약
- 항목 추가 후 X 자동 게시를 분리하고, admin에서 draft 검토/수정 후 게시하는 흐름으로 개선했습니다.
- main/replies를 분리해서 승인할 수 있도록 UX를 보강했습니다.
- 로컬에서 GitHub 토큰 없이도 흐름을 검증할 수 있도록 mock 모드를 추가했습니다(로컬 호스트 전용).

## 주요 변경
### 워크플로우
- .github/workflows/notify.yml: prepare 중심으로 정리 (자동 post 단계 분리)
- .github/workflows/post-approved.yml 추가: 승인된 thread를 workflow_dispatch로 게시
- .github/workflows/rewrite-x-draft.yml 추가: instruction 기반 AI rewrite

### admin UX
- 제출 시 "X 게시 전 draft 확인/수정 후 승인" 옵션 제공
- X draft 검토 패널 추가 (main/replies 편집, 글자수 카운트)
- main 승인 / replies 승인 분리 + 전체 승인 버튼 추가
- X 게시 버튼을 별도 액션으로 명확화
- main/replies/전체 스레드 복사 버튼 제공
- AI 수정 영역을 접을 수 있게 정리하고, target(main/replies/reply N) 기반 수정 지원
- 상태/문구 톤 정리 (draft 용어 통일)

### 안정성/운영
- mock 모드는 localhost에서만 활성화되도록 제한
- 게시/AI 수정 중복 실행 방지
- workflow 권한/404/응답 누락 시 안내 메시지 강화

## QA
- web 디렉터리에서 npm run build 성공
- 로컬 mock 모드에서 아래 플로우 확인
  - 항목 추가 → draft 생성
  - main/replies 개별 승인
  - 전체 승인 후 X 게시(시뮬레이션)
  - main/replies 개별 복사
  - AI 수정(main/replies target) 후 재승인

## 참고
- artifacts/는 로컬 테스트 산출물이며 커밋에 포함하지 않았습니다.
