### PR TITLE
Chore: summarize 스킬 출력을 코드 블록으로 감싸도록 개선

### DIFF
--- a/.claude/commands/summarize.md
+++ b/.claude/commands/summarize.md
@@ -146,7 +146,7 @@ After generating all summaries:
    - Use Bash to get the timestamp: `date +"%Y-%m-%d_%H%M"`
 2. Write all summaries to `~/claude-summarize/{timestamp}.md`
    - Multiple URL results go in a single file, separated by a blank line between items
-3. Display the generated markdown content to the user
+3. Display the generated markdown content to the user inside a fenced code block (```markdown ... ```) so they can copy it directly
 4. Show the saved file path as an absolute path so the user can click it directly:
    ```
    저장 경로: /Users/chanmuzi/claude-summarize/{timestamp}.md
@@ -158,3 +158,4 @@ After generating all summaries:
 - The markdown content in the file should contain ONLY the bullet-point summaries — no extra headers, metadata, or wrappers
 - Each item starts with `- {emoji}` at the top level
 - Separate multiple items with one blank line
+- Output ONLY the fenced code block and the saved file path — no greetings, explanations, or extra commentary


### PR DESCRIPTION
## 개요

/summarize 스킬의 결과를 fenced code block으로 출력하여 /copy 명령으로 바로 복사할 수 있도록 개선

## 변경 사항

- 요약 결과를 ```markdown 코드 블록으로 감싸서 출력하도록 지시 추가
- 불필요한 인사말/설명 없이 코드 블록 + 저장 경로만 출력하도록 제한

🤖 Generated with [Claude Code](https://claude.ai/code)