### PR TITLE
Docs: /post 스킬 artifacts JSON Write 전 Read 선행 안내

### DIFF
--- a/.claude/commands/post.md
+++ b/.claude/commands/post.md
@@ -129,7 +129,7 @@ Recommended flow:
    ```json
    { "main": "...", "replies": ["...", "..."] }
    ```
-   Use the `Write` tool — that handles arbitrary content safely.
+   Use the `Write` tool — that handles arbitrary content safely. **주의**: 이 파일은 이전 `/post` 실행 결과로 이미 존재할 수 있다. Write는 기존 파일을 덮어쓰기 전에 Read 선행을 요구하므로, Write 호출 전에 같은 경로를 한 번 Read한 뒤 Write를 호출한다 (Read 결과는 사용하지 않아도 됨).
 2. Validate:
    ```
    node scripts/x-length.mjs --json-file artifacts/post-skill-thread.json
@@ -189,7 +189,10 @@ The `**[메인]** (xx/260 · 280)` line shows the weighted char count from `x-le
 When the user replies `게시` / `승인` / `post` / `publish` (or the same with `드라이런` for dry-run):
 
 ### 4a. Write temp digest.json
-Create `artifacts/post-skill-digest.json` (artifacts/ is gitignored):
+Create `artifacts/post-skill-digest.json` (artifacts/ is gitignored).
+
+**주의**: 이 파일도 Step 2의 thread JSON과 마찬가지로 이전 실행 결과로 이미 존재할 수 있다. Write 호출 전에 같은 경로를 한 번 Read해서 "기존 파일을 읽었다"는 상태를 만든 뒤 Write를 호출한다. (Read 실패 = 신규 파일 → 바로 Write 가능, Read 성공 = 기존 파일 → 그 다음 Write가 통과한다.)
+
 ```json
 {
   "generated_at": "<ISO>",

--- a/.claude/commands/post.md
+++ b/.claude/commands/post.md
@@ -191,7 +191,7 @@ When the user replies `게시` / `승인` / `post` / `publish` (or the same with
 ### 4a. Write temp digest.json
 Create `artifacts/post-skill-digest.json` (artifacts/ is gitignored).
 
-**주의**: 이 파일도 Step 2의 thread JSON과 마찬가지로 이전 실행 결과로 이미 존재할 수 있다. Write 호출 전에 같은 경로를 한 번 Read해서 "기존 파일을 읽었다"는 상태를 만든 뒤 Write를 호출한다. (Read 실패 = 신규 파일 → 바로 Write 가능, Read 성공 = 기존 파일 → 그 다음 Write가 통과한다.)
+**주의**: 이 파일도 Step 2의 thread JSON과 마찬가지로 이전 실행 결과로 이미 존재할 수 있다. Write 호출 전에 같은 경로를 한 번 Read해서 "기존 파일을 읽었다"는 상태를 만든 뒤 Write를 호출한다. Read 결과가 `not found` / `does not exist`인 경우에만 신규 파일로 간주해 바로 Write를 진행한다. Read가 성공하면 기존 파일로 간주하고 그 다음 Write를 호출한다. 권한 문제, 잘못된 경로, 기타 I/O 오류 등 파일 미존재가 아닌 Read 실패는 신규 파일로 간주하지 말고 원인을 확인한 뒤 진행한다.
 
 ```json
 {


### PR DESCRIPTION
## 개요

`/post` 스킬 사용 시 `artifacts/post-skill-thread.json`, `artifacts/post-skill-digest.json` Write가 첫 시도에서 실패하던 문제를 가이드 차원에서 해결.

## 변경 사항

### 1. post.md 가이드 보강

- Step 2(`post-skill-thread.json`)와 Step 4a(`post-skill-digest.json`) 작성 절차에 "Write 호출 전 같은 경로를 한 번 Read한다"는 안내를 추가.
- 두 파일 모두 이전 `/post` 실행 결과로 디렉토리에 잔존하는데, Write 도구가 요구하는 read-before-write 조건을 사전에 충족시키지 못해 첫 Write가 InputValidationError로 실패하는 동작이 원인.
- 관련 커밋: 5b288ce

## 참고 사항

- 코드/스크립트 변경은 없음. 가이드 문서만 수정.
- 동일 패턴이 추가될 경우 같은 안내를 적용할 것.