### PR TITLE
Fix: /post 직접 게시 commit은 notify 드래프트 재생성 skip

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -26,6 +26,9 @@ permissions:
 
 jobs:
   prepare:
+    # /post 스킬은 X 게시 후 commit 본문에 "Posted to X: <URL>"을 항상 포함한다.
+    # 그 경우 이미 게시된 항목이므로 admin 승인용 드래프트를 다시 만들지 않는다.
+    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, 'Posted to X:') }}
     runs-on: ubuntu-latest
     outputs:
       added_count: ${{ steps.delta.outputs.added_count }}


### PR DESCRIPTION
## 개요

`/post` 스킬이 X에 직접 게시한 뒤 push되는 commit이 `notify.yml`에 의해 다시 admin 승인용 드래프트로 만들어져 동일 항목의 중복 게시 위험이 있었다. `prepare` job 진입 단계에서 이를 감지해 skip하도록 1줄 조건을 추가한다.

## 변경 사항

### 1. notify.yml prepare job에 skip 조건 추가

- push 이벤트에서 `head_commit.message`에 `"Posted to X:"` 문자열이 포함되면 `prepare` job을 skip
- `pull_request` / `workflow_dispatch` 트리거는 영향 없음 (조건이 push에만 적용)
- 신호로 사용하는 `Posted to X: <URL>` 라인은 별도 마커가 아니라, /post 스킬이 이미 게시 결과 추적용으로 commit 본문에 박는 정보 그대로를 재사용
- 관련 커밋: 567042f

## 참고 사항

- **의존하는 계약**: `~/.claude/commands/post.md`의 commit 템플릿이 `Posted to X: <URL>` 라인을 항상 포함해야 이 조건이 의미를 갖는다. 현재 템플릿은 이를 만족하지만, 추후 변경 시 silent하게 깨질 수 있음.
- **Follow-up**: PR #15(.claude/commands/post.md docs 수정)가 머지된 뒤, post.md에 "이 commit 메시지에 `Posted to X: <URL>`이 반드시 포함되어야 한다 — `notify.yml`이 이 문자열로 skip 판정함" 명시를 별도 PR로 추가할 예정.
- **검증 방법**: 이 PR이 머지된 후 다음 /post 흐름에서 GitHub Actions의 `Notify & Post to X` 워크플로우가 새 push에 대해 `prepare` job을 skip하는지 확인. admin UI에서 추가한 commit (Posted to X 문자열 없음)에 대해서는 정상 트리거되는지도 함께 확인.

## 관련 이슈/PR

- #15 (별개 PR이지만 같은 /post 흐름을 다루는 docs 변경)