### PR TITLE
Chore: notify 워크플로우 이름 정리 및 post 스킬 계약 명시

### DIFF
--- a/.claude/commands/post.md
+++ b/.claude/commands/post.md
@@ -242,7 +242,11 @@ EOF
 )"
 git push origin <current-branch>
 ```
-The push triggers `notify.yml` (which generates another draft for the admin UI — harmless, just ignore it) and `deploy.yml` (which updates the site). Mention this to the user.
+
+**중요 — `Posted to X: <URL>` 라인은 절대 제거하지 말 것.**
+`.github/workflows/notify.yml`의 `prepare` job은 push 이벤트의 `head_commit.message`에 `Posted to X:` 문자열이 포함되어 있으면 admin 승인용 드래프트 생성을 skip한다. 이 라인을 빼면 동일 항목으로 드래프트가 재생성되어 사용자가 무심코 승인 시 **중복 게시**가 발생할 수 있다. 메시지 형식(`Posted to X: <URL>`)은 그대로 유지한다.
+
+The push triggers `notify.yml` (which detects the `Posted to X:` line and skips draft generation — so no duplicate draft is created) and `deploy.yml` (which updates the site). Mention to the user that the deploy workflow runs.
 
 **Dry-run mode:**
 - Skip `add-item.mjs`, skip commit, skip push.

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,4 +1,4 @@
-name: Notify & Post to X
+name: Prepare X Thread Draft
 
 on:
   push:


### PR DESCRIPTION
## 개요

`/post` 흐름이 명확히 보이도록 두 군데를 정리한다 — `notify.yml` 워크플로우 이름을 실제 동작과 일치시키고, `Posted to X:` 라인이 skip 신호로 사용된다는 계약을 `/post` 스킬 정의에 명시한다.

## 변경 사항

### 1. notify.yml 워크플로우 이름 변경

- `Notify & Post to X` → `Prepare X Thread Draft`로 변경
- 기존 이름은 마치 X에 직접 게시하는 것처럼 보였으나, 실제로는 admin 승인용 드래프트만 생성하고 게시는 `post-approved.yml`(workflow_dispatch)에서 수행
- GitHub Actions UI에서 `/post` 흐름의 push로 생성되는 skipped run의 표시 의미가 정확해짐
- 관련 커밋: 0bf2d3a

### 2. /post 스킬 정의에 skip 신호 계약 명시

- `.claude/commands/post.md` Step 4c의 commit 템플릿 직후에 \"Posted to X: <URL> 라인은 절대 제거 금지\" 단락 추가
- `notify.yml`의 prepare job이 `head_commit.message`에 `Posted to X:`가 포함되면 skip하므로, 이 라인을 빼면 동일 항목으로 admin 드래프트가 재생성되어 중복 게시 위험
- 그 아래 push trigger 동작 설명도 PR #16 머지 후 실제 동작(skip)에 맞게 갱신
- 관련 커밋: 1e28f6d

## 참고 사항

- 두 변경은 모두 \"/post 흐름의 의도가 워크플로우 이름·문서 모두에서 일관되게 드러나도록\" 한다는 단일 의도로 묶었다.
- 워크플로우 동작(prepare job의 if 조건) 자체는 #16에서 이미 처리됐으며, 이번 PR은 그 위의 가독성·계약 명시 작업이다.

## 관련 이슈/PR

- #16 (notify.yml prepare job skip 조건 도입)
- #15 (이전 post.md docs 수정)